### PR TITLE
feat: @西寶 mention responses + fortune draw

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,21 @@ For URL-only payloads (fixer links), the bot waits `EMBED_CHECK_DELAY_MS` then r
 | `PLAYWRIGHT_GOTO_TIMEOUT_MS` | `8000` | Inside threads-probe |
 | `PLAYWRIGHT_META_WAIT_TIMEOUT_MS` | `1500` | Inside threads-probe |
 
+## @西寶 mention responses
+
+When a user mentions the bot (@西寶), the bot checks the message text after stripping the mention:
+
+| Text | Response |
+|---|---|
+| `抽籤` | Weighted fortune draw: 大吉/中吉/小吉/末吉/吉/凶/大凶, with a tier-specific comment |
+| `道歉` | `"對不起對不起…我知道我不好…///"` |
+| *(blank)* | Random shy greeting (e.g. `"有、有什麼事嗎…？///"`) |
+| *(anything else)* | `"你…你在叫我嗎？///"` |
+
+Fortune tiers (weighted): 大吉 10%, 中吉 16%, 小吉 20%, 末吉 20%, 吉 15%, 凶 13%, 大凶 6%
+
+Bot personality (西寶): shy, flustered, self-deprecating. Uses `///` and ellipses `…`.
+
 ## Ignore markers
 
 Users can suppress the bot by including `nopreview`, `previewignore`, or `fxignore` anywhere in their message.
@@ -89,6 +104,7 @@ macOS convenience scripts: `start-bot.command` / `stop-bot.command`
 
 - New features go on a `feature/*` branch, never directly to `main`.
 - Open a PR to merge into `main`.
+- After changes are committed and pushed, restart the bot via `stop-bot.command` then `start-bot.command`.
 
 ## Notes
 
@@ -96,3 +112,4 @@ macOS convenience scripts: `start-bot.command` / `stop-bot.command`
 - Dedup window: same channel + URL won't trigger a second reply within 60 seconds (`DEDUPE_WINDOW_MS`).
 - `inFlightReplies` Set prevents duplicate processing of the same message if `messageCreate` fires twice.
 - Log prefix convention: `[preview]`, `[threads-meta]` for easy filtering.
+- Mention text must be `.normalize("NFC")` before comparison — Discord can send CJK input in NFD form, causing strict equality to silently fail (e.g. `抽籤` not matching).

--- a/src/index.js
+++ b/src/index.js
@@ -1084,7 +1084,6 @@ client.on("messageCreate", async (message) => {
       .normalize("NFC")
       .trim();
     const textLower = text.toLowerCase();
-    console.log(`[mention] text=${JSON.stringify(text)} hex=${Buffer.from(text).toString("hex")}`);
 
     if (textLower === "抽籤") {
       const result = drawFortune();

--- a/src/index.js
+++ b/src/index.js
@@ -1081,8 +1081,10 @@ client.on("messageCreate", async (message) => {
   if (isMentioningBot(message)) {
     const text = message.content
       .replace(/<@!?\d+>/g, "")
+      .normalize("NFC")
       .trim();
     const textLower = text.toLowerCase();
+    console.log(`[mention] text=${JSON.stringify(text)} hex=${Buffer.from(text).toString("hex")}`);
 
     if (textLower === "抽籤") {
       const result = drawFortune();

--- a/src/index.js
+++ b/src/index.js
@@ -1044,6 +1044,16 @@ const FORTUNE_RESULTS = [
   { label: "大凶", weight: 10 },
 ];
 
+const FORTUNE_COMMENTS = {
+  "大吉": ["今天會是很好的一天喔！", "哇…真的嗎…好厲害！", "運氣超好的…羨慕///"],
+  "中吉": ["還不錯啦…差不多啦。", "算是好的吧…應該啦…", "嗯…不差不差。"],
+  "小吉": ["還好啦…小小的幸運～", "有一點點好運喔。", "差強人意…吧？"],
+  "末吉": ["唔…勉強算吉吧…", "就…就還行吧？", "平平淡淡的一天。"],
+  "吉":   ["普通普通…", "就是正常啦～", "嗯，還行喔！"],
+  "凶":   ["今天要小心一點喔…", "有點不好耶…好擔心…", "…要注意安全喔。"],
+  "大凶": ["啊、對不起…抽到大凶了…", "不、不要難過…！明天會更好的…", "今天就乖乖待在家吧…///"],
+};
+
 function drawFortune() {
   const total = FORTUNE_RESULTS.reduce((sum, r) => sum + r.weight, 0);
   let rand = Math.floor(Math.random() * total);
@@ -1052,6 +1062,10 @@ function drawFortune() {
     if (rand < 0) return result.label;
   }
   return FORTUNE_RESULTS.at(-1).label;
+}
+
+function pickRandom(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
 }
 
 function isMentioningBot(message) {
@@ -1067,25 +1081,47 @@ client.on("messageCreate", async (message) => {
   if (isMentioningBot(message)) {
     const text = message.content
       .replace(/<@!?\d+>/g, "")
-      .trim()
-      .toLowerCase();
+      .trim();
+    const textLower = text.toLowerCase();
 
-    if (text === "抽籤") {
+    if (textLower === "抽籤") {
       const result = drawFortune();
+      const comment = pickRandom(FORTUNE_COMMENTS[result]);
       await message.reply({
-        content: `抽到了… **${result}** ！`,
+        content: `🎋 今日運勢：**${result}**\n${comment}`,
+        allowedMentions: { repliedUser: false },
+      });
+      return;
+    }
+
+    if (textLower === "道歉") {
+      await message.reply({
+        content: "對不起對不起…我知道我不好…///",
         allowedMentions: { repliedUser: false },
       });
       return;
     }
 
     if (text === "") {
+      const greetings = [
+        "哎呀…突然叫我幹嘛…",
+        "有、有什麼事嗎…？///",
+        "嗯…？叫我了嗎…",
+        "…在的在的…怎麼了嗎？",
+      ];
       await message.reply({
-        content: "有、有什麼事嗎…？///" ,
+        content: pickRandom(greetings),
         allowedMentions: { repliedUser: false },
       });
       return;
     }
+
+    // Unknown command — still a mention, respond shyly
+    await message.reply({
+      content: "你…你在叫我嗎？///",
+      allowedMentions: { repliedUser: false },
+    });
+    return;
   }
 
   const urls = extractSupportedUrls(message.content);

--- a/src/index.js
+++ b/src/index.js
@@ -1035,13 +1035,13 @@ client.on("interactionCreate", async (interaction) => {
 });
 
 const FORTUNE_RESULTS = [
-  { label: "大吉", weight: 5 },
-  { label: "中吉", weight: 15 },
+  { label: "大吉", weight: 10 },
+  { label: "中吉", weight: 16 },
   { label: "小吉", weight: 20 },
   { label: "末吉", weight: 20 },
   { label: "吉",   weight: 15 },
-  { label: "凶",   weight: 15 },
-  { label: "大凶", weight: 10 },
+  { label: "凶",   weight: 13 },
+  { label: "大凶", weight: 6 },
 ];
 
 const FORTUNE_COMMENTS = {


### PR DESCRIPTION
## Summary
- 新增 @西寶 mention 觸發回應：`抽籤`（加權抽運勢）、`道歉`、空訊息隨機問候、其他訊息預設回應
- 運勢調整：大吉 5→10%、大凶 10→6%，整體略微右傾（偏正向）
- 修正 mention 比對：文字先 `.normalize("NFC")` 才比對（避免 Discord 傳 NFD 造成 `抽籤` 不匹配）
- 更新 CLAUDE.md 對齊實際行為 + 補上 push 後重啟提醒

## Test plan
- [ ] @西寶 抽籤 多抽幾次驗證七種結果都會出現
- [ ] @西寶 道歉 回覆固定道歉文
- [ ] @西寶（空訊息）隨機問候
- [ ] @西寶 亂打 回覆預設
- [ ] Pull + 重啟後分佈以新權重為準

🤖 Generated with [Claude Code](https://claude.com/claude-code)