### PR TITLE
feat: Threads multi-image carousel embed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -495,13 +495,14 @@ async function fetchThreadsMetadata(url) {
   const metadata = JSON.parse(stdout);
 
   console.log(
-    `[threads-meta] metaTags=${metadata.metaTagCount} title=${metadata.title ? "yes" : "no"} desc=${metadata.description ? "yes" : "no"} image=${metadata.image ? "yes" : "no"} card=${metadata.twitterCard ?? "null"} imageCount=${metadata.imageCount ?? 0} videoCount=${metadata.videoCount ?? 0} source=playwright-subprocess`,
+    `[threads-meta] metaTags=${metadata.metaTagCount} title=${metadata.title ? "yes" : "no"} desc=${metadata.description ? "yes" : "no"} image=${metadata.image ? "yes" : "no"} card=${metadata.twitterCard ?? "null"} imageCount=${metadata.imageCount ?? 0} imagesLen=${metadata.images?.length ?? 0} videoCount=${metadata.videoCount ?? 0} source=playwright-subprocess`,
   );
 
   const result = {
     title: metadata.title,
     description: metadata.description,
     image: metadata.image,
+    images: metadata.images || [],
     twitterCard: metadata.twitterCard,
     video: metadata.video,
     imageCount: metadata.imageCount || 0,
@@ -706,6 +707,9 @@ async function buildPreviewPayloads(urls) {
       if (metadata.video || metadata.videoCount > 0) {
         console.log(`[preview] threads-video fixer ${url}`);
         const videoFallbackEmbed = buildThreadsCompactEmbed(url, metadata);
+        if (!metadata.title) {
+          videoFallbackEmbed.setTitle("Threads 影片貼文");
+        }
         const videoDesc = metadata.description
           ? trimDescription(metadata.description, 3900) + "\n\n（影片無法載入，請點連結觀看）"
           : "（影片無法載入，請點連結觀看）";

--- a/src/index.js
+++ b/src/index.js
@@ -729,11 +729,24 @@ async function buildPreviewPayloads(urls) {
       }
 
       if (metadata.imageCount > 1) {
-        console.log(`[preview] threads-multi-image ${url}`);
-        payloads.push({
-          embeds: [buildThreadsMediaEmbed(url, metadata)],
-          components: [buildThreadsLinkRow(url)],
-        });
+        const allImages = metadata.images && metadata.images.length > 1
+          ? metadata.images.slice(0, 10)
+          : null;
+
+        if (allImages) {
+          console.log(`[preview] threads-multi-image carousel count=${allImages.length} ${url}`);
+          const firstEmbed = buildThreadsMediaEmbed(url, { ...metadata, image: allImages[0] });
+          const restEmbeds = allImages.slice(1).map((imgUrl) =>
+            new EmbedBuilder().setURL(url).setImage(imgUrl).setColor(THREADS_EMBED_COLOR)
+          );
+          payloads.push({ embeds: [firstEmbed, ...restEmbeds] });
+        } else {
+          console.log(`[preview] threads-multi-image fallback ${url}`);
+          payloads.push({
+            embeds: [buildThreadsMediaEmbed(url, metadata)],
+            components: [buildThreadsLinkRow(url)],
+          });
+        }
         continue;
       }
 

--- a/src/threads-probe.cjs
+++ b/src/threads-probe.cjs
@@ -123,6 +123,7 @@ async function readThreadsMetadata(page) {
           getMeta("name", "twitter:player:stream") ||
           candidateVideos[0]?.getAttribute("src") ||
           null,
+        images: candidateImages.map((img) => img.src).filter(Boolean),
         imageCount: candidateImages.length,
         videoCount: Math.max(
           candidateVideos.length,

--- a/src/threads-probe.cjs
+++ b/src/threads-probe.cjs
@@ -84,18 +84,27 @@ async function readThreadsMetadata(page) {
         return element?.getAttribute("content")?.trim() || null;
       };
 
+      const getBestSrc = (img) => {
+        if (img.srcset) {
+          const candidates = img.srcset.split(",")
+            .map((s) => { const p = s.trim().split(/\s+/); return { url: p[0], w: parseInt(p[1]) || 0 }; })
+            .filter((c) => c.url.startsWith("http"))
+            .sort((a, b) => b.w - a.w);
+          if (candidates.length > 0) return candidates[0].url;
+        }
+        return img.currentSrc || img.src || img.getAttribute("src") || null;
+      };
+
+      // 只取主貼文範圍的圖（viewport 內）；留言在 viewport 以下
+      const viewportHeight = window.innerHeight;
       const mediaContainer = document.querySelector("article") || document.body;
       const candidateImages = Array.from(
         mediaContainer.querySelectorAll("img"),
       ).filter((img) => {
         const rect = img.getBoundingClientRect();
-        const src = img.getAttribute("src") || "";
-
-        if (!src) {
-          return false;
-        }
-
-        return rect.width >= 160 && rect.height >= 160;
+        if (rect.top >= viewportHeight) return false; // 留言區
+        const src = getBestSrc(img);
+        return src && rect.width >= 160 && rect.height >= 160;
       });
 
       const candidateVideos = Array.from(document.querySelectorAll("video"));
@@ -123,7 +132,7 @@ async function readThreadsMetadata(page) {
           getMeta("name", "twitter:player:stream") ||
           candidateVideos[0]?.getAttribute("src") ||
           null,
-        images: candidateImages.map((img) => img.currentSrc || img.src || img.getAttribute("src") || null).filter(Boolean),
+        images: candidateImages.map((img) => getBestSrc(img)).filter(Boolean),
         imageCount: candidateImages.length,
         videoCount: Math.max(
           candidateVideos.length,

--- a/src/threads-probe.cjs
+++ b/src/threads-probe.cjs
@@ -123,7 +123,7 @@ async function readThreadsMetadata(page) {
           getMeta("name", "twitter:player:stream") ||
           candidateVideos[0]?.getAttribute("src") ||
           null,
-        images: candidateImages.map((img) => img.src).filter(Boolean),
+        images: candidateImages.map((img) => img.currentSrc || img.src || img.getAttribute("src") || null).filter(Boolean),
         imageCount: candidateImages.length,
         videoCount: Math.max(
           candidateVideos.length,


### PR DESCRIPTION
## Summary
- 多圖貼文改為全圖集顯示（每張圖各一個 embed，Discord 渲染成 gallery）
- probe 用 `srcset` 最高解析度取代縮圖 URL
- viewport-height guard 過濾留言區圖片，只取主貼文 carousel 範圍
- 影片 embed fallback 加預設 title（避免 OG title 為 null 時 embed 顯示空白）
- `imagesLen` 加入 `[threads-meta]` log 方便診斷

## Test plan
- [ ] 多圖貼文：顯示全部圖片 gallery，無「查看全部圖片」按鈕
- [ ] 多圖貼文：圖片畫質正常，無留言圖片混入
- [ ] 影片貼文：fixer 失敗時顯示標題 + 「影片無法載入，請點連結觀看」
- [ ] 單圖貼文：行為不受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)