### PR TITLE
feat: strip tracking params from URLs before preview

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,3 +113,4 @@ macOS convenience scripts: `start-bot.command` / `stop-bot.command`
 - `inFlightReplies` Set prevents duplicate processing of the same message if `messageCreate` fires twice.
 - Log prefix convention: `[preview]`, `[threads-meta]` for easy filtering.
 - Mention text must be `.normalize("NFC")` before comparison — Discord can send CJK input in NFD form, causing strict equality to silently fail (e.g. `抽籤` not matching).
+- `normalizeUrl` strips tracking params before any routing/dedupe. Two lists: `UNIVERSAL_TRACKING_PARAMS` (stripped on any host — UTM, click IDs like `fbclid`/`gclid`, `mibextid`, etc.) and `HOST_GATED_TRACKING_PARAMS` (stripped only on matching hosts — e.g. `t`/`s` on X/Twitter but NOT on YouTube where `t` is a timestamp; `igsh*` on Instagram; Bilibili `share_*`/`spm_id_from`/etc.). When adding a param, decide if it's meaningful on any supported host — if yes, gate it.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@
 - Deduplicates repeated previews in the same channel
 - Suppresses the original embed if the bot has `Manage Messages`
 - Uses Playwright only for Threads metadata extraction
-- Normalizes common tracking query parameters before dedupe
+- Strips common tracking parameters (`fbclid`, `gclid`, `mibextid`, `utm_*`, `igsh`, etc.) from URLs before replying — protects the poster from leaking share-tracking info, and improves dedupe
 - Bilibili short links (`b23.tv`) are expanded before fixer routing
 - Registers a `/servers` slash command so you can check how many guilds the bot is in from Discord
 - Registers a `/debug-perms` slash command so you can check the bot's channel permissions from Discord

--- a/src/index.js
+++ b/src/index.js
@@ -92,6 +92,19 @@ const FACEBOOK_HOSTS = new Set([
   "m.facebook.com",
   "fb.watch",
 ]);
+const TWITTER_HOSTS = new Set([
+  "x.com",
+  "www.x.com",
+  "twitter.com",
+  "www.twitter.com",
+  "mobile.twitter.com",
+]);
+const YOUTUBE_HOSTS = new Set([
+  "youtube.com",
+  "www.youtube.com",
+  "m.youtube.com",
+  "youtu.be",
+]);
 
 const SUPPORTED_HOSTS = new Set([
   ...THREADS_HOSTS,
@@ -151,36 +164,91 @@ const REQUIRED_CHANNEL_PERMISSIONS = [
   },
 ];
 
+// Tracking / analytics params that leak personal info but never affect the
+// resource being referenced. Safe to strip on any host.
+const UNIVERSAL_TRACKING_PARAMS = [
+  // UTM (Urchin Tracking Module)
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+  "utm_id",
+  "utm_name",
+  "utm_reader",
+  // Ad-network click IDs
+  "fbclid",   // Facebook
+  "gclid",    // Google Ads
+  "gbraid",   // Google (iOS)
+  "wbraid",   // Google (iOS)
+  "dclid",    // DoubleClick
+  "msclkid",  // Microsoft / Bing
+  "yclid",    // Yandex
+  "twclid",   // Twitter Ads
+  "ttclid",   // TikTok
+  "li_fat_id", // LinkedIn
+  // Meta (FB / IG / Threads) browser-extension share tracker
+  "mibextid",
+  // Email campaign
+  "mc_cid",
+  "mc_eid",
+  // Google Analytics cross-domain
+  "_ga",
+  "_gl",
+  // Generic referrer trackers
+  "ref_src",
+  "ref_url",
+  // Misc Meta
+  "xmt",
+  "slof",
+];
+
+// Params that are tracking on some hosts but meaningful on others, so they
+// must be gated. Keys are param names; values are host Sets where stripping
+// is safe (i.e. the param is tracking there).
+const HOST_GATED_TRACKING_PARAMS = [
+  // Instagram share tracker
+  { param: "igsh", hosts: INSTAGRAM_HOSTS },
+  { param: "igshid", hosts: INSTAGRAM_HOSTS },
+  // X / Twitter share analytics (t + s pair appears on share URLs; t= there
+  // is NOT a timestamp like on YouTube)
+  { param: "t", hosts: TWITTER_HOSTS },
+  { param: "s", hosts: TWITTER_HOSTS },
+  // YouTube share identifier / feature / share payload
+  // Note: do NOT strip `t` on YouTube — it is the timestamp jump.
+  { param: "si", hosts: YOUTUBE_HOSTS },
+  { param: "feature", hosts: YOUTUBE_HOSTS },
+  { param: "pp", hosts: YOUTUBE_HOSTS },
+  // Bilibili tracking/share (existing set, kept host-gated to avoid collisions)
+  { param: "spm_id_from", hosts: BILIBILI_HOSTS },
+  { param: "trackid", hosts: BILIBILI_HOSTS },
+  { param: "vd_source", hosts: BILIBILI_HOSTS },
+  { param: "from", hosts: BILIBILI_HOSTS },
+  { param: "from_spmid", hosts: BILIBILI_HOSTS },
+  { param: "seid", hosts: BILIBILI_HOSTS },
+  { param: "share_source", hosts: BILIBILI_HOSTS },
+  { param: "share_medium", hosts: BILIBILI_HOSTS },
+  { param: "share_plat", hosts: BILIBILI_HOSTS },
+  { param: "share_session_id", hosts: BILIBILI_HOSTS },
+  { param: "share_tag", hosts: BILIBILI_HOSTS },
+  { param: "timestamp", hosts: BILIBILI_HOSTS },
+  { param: "unique_k", hosts: BILIBILI_HOSTS },
+  { param: "upsig", hosts: BILIBILI_HOSTS },
+];
+
 function normalizeUrl(rawUrl) {
   const url = new URL(rawUrl);
-  url.searchParams.delete("xmt");
-  url.searchParams.delete("slof");
-  // Bilibili tracking params
-  url.searchParams.delete("spm_id_from");
-  url.searchParams.delete("trackid");
-  url.searchParams.delete("vd_source");
-  url.searchParams.delete("from");
-  url.searchParams.delete("from_spmid");
-  url.searchParams.delete("seid");
-  url.searchParams.delete("share_source");
-  url.searchParams.delete("share_medium");
-  url.searchParams.delete("share_plat");
-  url.searchParams.delete("share_session_id");
-  url.searchParams.delete("share_tag");
-  url.searchParams.delete("timestamp");
-  url.searchParams.delete("unique_k");
-  url.searchParams.delete("upsig");
-  // Universal UTM params
-  url.searchParams.delete("utm_source");
-  url.searchParams.delete("utm_medium");
-  url.searchParams.delete("utm_campaign");
-  url.searchParams.delete("utm_term");
-  url.searchParams.delete("utm_content");
-  // Instagram-specific tracking params
-  if (INSTAGRAM_HOSTS.has(url.hostname)) {
-    url.searchParams.delete("igsh");
-    url.searchParams.delete("igshid");
+
+  for (const param of UNIVERSAL_TRACKING_PARAMS) {
+    url.searchParams.delete(param);
   }
+
+  for (const { param, hosts } of HOST_GATED_TRACKING_PARAMS) {
+    if (hosts.has(url.hostname)) {
+      url.searchParams.delete(param);
+    }
+  }
+
   return url.toString();
 }
 


### PR DESCRIPTION
## Summary
- 使用者貼出的 URL 常帶有 share-tracking ID（`fbclid`、`mibextid`、`utm_*`、`igsh`、X 的 `t`/`s` 等），會把個人資訊外洩到頻道上。擴充 `normalizeUrl`，在 routing / dedupe / 回覆輸出前先剝除。
- 重構成兩張清單：
  - `UNIVERSAL_TRACKING_PARAMS`：所有 host 都剝（UTM、ad-network click IDs、Meta `mibextid`、email campaign、`_ga`、`ref_src`…）
  - `HOST_GATED_TRACKING_PARAMS`：只在指定 host 剝，避免誤傷有意義的參數 — 特別是 **YouTube 的 `?t=` 是時間戳不是追蹤碼**，所以 `t` 只在 x.com/twitter.com 上剝。
- 新增 `TWITTER_HOSTS` / `YOUTUBE_HOSTS` 常數供 gate 使用。

## Verified cases
- Facebook story URL `?story_fbid=...&id=...&mibextid=wwXlfr` → 剝除 `mibextid`，保留 `story_fbid` 與 `id`（貼文 ID 不能動）
- X 分享連結 `?t=abc&s=46` → 都剝除
- YouTube `youtu.be/ID?t=120&si=xyz` → 保留 `?t=120`（跳到影片 2:00），剝除 `?si`
- Instagram `?igsh=...&igshid=...` → 都剝除
- 任意站 `?fbclid=123&utm_source=mail&keep=1` → 只留 `?keep=1`

## Test plan
- [ ] 貼 Facebook `story.php` 網址 → 輸出的 `facebed.com` 連結不含 `mibextid`
- [ ] 貼 X 分享連結（含 `?t=` 和 `?s=`）→ 輸出的 `fxtwitter.com` 連結乾淨
- [ ] 貼 YouTube 帶時間戳的連結 → `?t=` 被保留（可以實測 Discord 上播放是否跳到指定秒數）
- [ ] 貼 Instagram Reel 含 `igsh` → `ddinstagram.com` 連結不含 `igsh`
- [ ] 同頻道重複貼同一網址的「原始版」與「帶追蹤碼版」→ 應觸發 dedupe（因為 normalize 後相同）