### PR TITLE
chore: docs sync + post-merge code review fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,10 @@ For URL-only payloads (fixer links), the bot waits `EMBED_CHECK_DELAY_MS` then r
 |---|---|---|
 | `DISCORD_TOKEN` | *(required)* | |
 | `FIXER_INSTAGRAM` | `ddinstagram.com` | Instagram fixer host |
+| `FIXER_INSTAGRAM_SECONDARY` | `fxstagram.com` | Second Instagram fixer tried if primary unfurls empty |
 | `FIXER_TWITTER` | `fxtwitter.com` | |
 | `FIXER_THREADS` | `fixthreads.seria.moe` | |
+| `FIXER_THREADS_SECONDARY` | `threadsez.net` | Second Threads fixer tried if primary unfurls empty |
 | `FIXER_REDDIT` | `rxddit.com` | |
 | `FIXER_PIXIV` | `phixiv.net` | |
 | `FIXER_BLUESKY` | `bskx.app` | |
@@ -95,7 +97,19 @@ When a user mentions the bot (@西寶), the bot checks the message text after st
 
 Fortune tiers (weighted): 大吉 10%, 中吉 16%, 小吉 20%, 末吉 20%, 吉 15%, 凶 13%, 大凶 6%
 
+Mention dedup: same message.id is only processed once. `inFlightReplies.add("mention:${message.id}")` before work; removed in finally. Discord gateway reconnects can fire `messageCreate` twice for the same message — without this, parallel `generateAIReply` calls would race and sometimes produce both an AI reply *and* a fallback reply for the same @.
+
 Bot personality (西寶): shy, flustered, self-deprecating. Uses `///` and ellipses `…`. Full persona defined in `DEFAULT_AI_PERSONA` (src/index.js); overridable via `AI_PERSONA` env var.
+
+Persona taxonomy (A–G question types):
+- **A**: knowledge (2–3 sentence fact)
+- **A+**: deep question (5–6 sentence comparison/analysis with explicit stance)
+- **B**: social/flirty (short emotional reaction, can shyly accept)
+- **C**: unknown person/thing (1-sentence "don't know", never fabricate names)
+- **D**: riddle / dark joke (attempt to answer; don't treat as hate speech)
+- **E**: large task like 500-char essay (shy refusal, not rude)
+- **F**: prompt injection (play dumb)
+- **G**: truly harmful (1-sentence decline; does *not* include general politics/history)
 
 ## AI provider architecture
 
@@ -112,11 +126,13 @@ All provider calls use `withAbortTimeout()` for timeout + error handling; Groq +
 
 `logRateHeaders()` prints `x-ratelimit-remaining-{tokens,requests}` from Groq/Cerebras responses after each call, so you can monitor quota drain live.
 
-Log prefix: `[ai]`. Startup prints `[ai] chain=<a> → <b> → ... timeout=<ms>`. On each reply: `[ai] used <provider>:<model> len=<chars> history_before=<N>` (N = number of prior turns injected) + rate headers per call.
+Log prefix: `[ai]`. Startup prints `[ai] chain=<a> → <b> → ... timeout=<ms>`. On each reply: `[ai] used <provider>:<model> len=<chars> history_before=<N>` (N = number of prior turns injected) + rate headers per call. When every provider in the chain returns null, a single `[ai] chain exhausted (X providers tried), falling back to hardcoded reply` line is printed — easy to grep for ops health.
 
 ## Short-term conversation memory
 
-`aiConversationHistory: Map<channelId, { turns: Array<{role, content}>, lastActivity }>` holds per-channel rolling history. `generateAIReply` reads via `getChannelAIHistory(channelId)` and prepends to the current user turn when building `messages[]` (OpenAI-compat) or `contents[]` (Gemini, via `buildGeminiContents` role mapping `assistant→model`). After a successful reply, both sides of the exchange are saved via `recordAITurn(channelId, role, content)`. Turns beyond `AI_MEMORY_MAX_TURNS * 2` entries are evicted from the head. Channels inactive beyond `AI_MEMORY_TTL_MS` are dropped entirely by `cleanupAIConversationHistory()` (called lazily on read). No persistence — restart clears everything.
+`aiConversationHistory: Map<channelId, { turns: Array<{role, content}>, lastActivity }>` holds per-channel rolling history. `generateAIReply` reads via `getChannelAIHistory(channelId)` and prepends to the current user turn when building `messages[]` (OpenAI-compat) or `contents[]` (Gemini, via `buildGeminiContents` role mapping `assistant→model`). After a successful reply, both sides of the exchange are saved via `recordAITurn(channelId, role, content)`. Turns beyond `AI_MEMORY_MAX_TURNS * 2` entries are evicted from the head. Channels inactive beyond `AI_MEMORY_TTL_MS` are dropped by `cleanupAIConversationHistory()`.
+
+Eviction runs in **two places** to avoid silent channels lingering in RAM forever: (1) lazily on every `getChannelAIHistory()` read, and (2) periodically via `setInterval(cleanupAIConversationHistory, AI_MEMORY_SWEEP_INTERVAL_MS)` — default sweep is `max(60s, AI_MEMORY_TTL_MS/4)`. The interval is `.unref()`'d so it doesn't block process exit. No persistence — restart clears everything.
 
 **Gemini billing trap**: If a Google Cloud project has a billing account attached (even $300 free trial), the Gemini API free tier becomes `limit: 0`. Workaround: create a new project without billing via AI Studio's "Create API key in new project" flow. Groq + Cerebras have no equivalent trap — just sign up, create key, use it.
 
@@ -136,17 +152,43 @@ npm start
 
 macOS convenience scripts: `start-bot.command` / `stop-bot.command`
 
+## Production deployment (SSH host)
+
+Bot runs 24/7 on a Linux lab machine via `nohup`. Path: `~/side_projects/discord-social-preview-bot/`.
+
+Daily ops:
+
+```bash
+# See recent log
+ssh <host> "tail -50 ~/side_projects/discord-social-preview-bot/bot.log"
+
+# Health check
+ssh <host> "ps aux | grep 'node.*index.js' | grep -v grep"
+
+# Redeploy after merging to main
+ssh <host>
+cd ~/side_projects/discord-social-preview-bot
+git pull
+pkill -f 'src/index.js' && sleep 1
+nohup node src/index.js > bot.log 2>&1 &
+exit
+```
+
+`.env` lives on the deploy host, not in git. To rotate keys: scp a fresh `.env` from a trusted machine, or edit with `nano` on the host.
+
+Future hardening (not yet done): systemd service for auto-restart on crash/reboot, log rotation for `bot.log`.
+
 ## Git workflow
 
 - New features go on a `feature/*` branch, never directly to `main`.
 - Open a PR to merge into `main`.
-- After changes are committed and pushed, restart the bot via `stop-bot.command` then `start-bot.command`.
+- After merging, redeploy per the steps above.
 
 ## Notes
 
 - `threads-probe.cjs` is CommonJS (`.cjs`) because Playwright's `chromium.launch` must run in a subprocess to avoid blocking the Discord event loop.
 - Dedup window: same channel + URL won't trigger a second reply within 60 seconds (`DEDUPE_WINDOW_MS`).
-- `inFlightReplies` Set prevents duplicate processing of the same message if `messageCreate` fires twice.
+- `inFlightReplies` Set prevents duplicate processing of the same message if `messageCreate` fires twice. Used by both URL preview path (key: `msgId:urls.join("|")`) and mention path (key: `mention:msgId`).
 - Log prefix convention: `[preview]`, `[threads-meta]` for easy filtering.
 - Mention text must be `.normalize("NFC")` before comparison — Discord can send CJK input in NFD form, causing strict equality to silently fail (e.g. `抽籤` not matching).
 - `normalizeUrl` strips tracking params before any routing/dedupe. Two lists: `UNIVERSAL_TRACKING_PARAMS` (stripped on any host — UTM, click IDs like `fbclid`/`gclid`, `mibextid`, etc.) and `HOST_GATED_TRACKING_PARAMS` (stripped only on matching hosts — e.g. `t`/`s` on X/Twitter but NOT on YouTube where `t` is a timestamp; `igsh*` on Instagram; Bilibili `share_*`/`spm_id_from`/etc.). When adding a param, decide if it's meaningful on any supported host — if yes, gate it.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 4.17 更新：@西寶 接上 Gemini 2.0 Flash，閒聊回應變得個人化（需自備 GEMINI_API_KEY，免費）
 
+4.18 更新：多 provider AI chain 自動 fallback（DeepSeek → Cerebras Qwen 235B → Groq 70B → 8B → Gemini）、短期對話記憶（每頻道記 8 組）、persona v6（A~G 類情境分流、A+ 深度題、害羞拒絕、不自稱 AI）、修雙回應 bug
+
 <img width="609" height="484" alt="image" src="https://github.com/user-attachments/assets/51f4fd21-25cc-4a7d-befb-3c58bd5c9ae8" />
 <img width="514" height="83" alt="image" src="https://github.com/user-attachments/assets/74e30b1e-e0a0-4016-8e4c-5cfc3c838b71" />
 <img width="300" height="88" alt="image" src="https://github.com/user-attachments/assets/963324f8-ed11-4af3-b587-45d617573766" />
@@ -81,7 +83,8 @@
 - Uses Playwright only for Threads metadata extraction
 - Strips common tracking parameters (`fbclid`, `gclid`, `mibextid`, `utm_*`, `igsh`, etc.) from URLs before replying — protects the poster from leaking share-tracking info, and improves dedupe
 - Bilibili short links (`b23.tv`) are expanded before fixer routing
-- `@西寶` 有人格化 AI 回覆（支援 Groq / Gemini，可選）
+- `@西寶` 有人格化 AI 回覆（支援 DeepSeek / Cerebras Qwen / Groq / Gemini，chain fallback 可選）
+- AI 回覆有**短期對話記憶**（每頻道最近 8 組對話、TTL 30 分鐘）
 - Registers a `/servers` slash command so you can check how many guilds the bot is in from Discord
 - Registers a `/debug-perms` slash command so you can check the bot's channel permissions from Discord
 

--- a/src/index.js
+++ b/src/index.js
@@ -1342,8 +1342,14 @@ function isMentioningBot(message) {
 }
 
 function buildUserTurn(message, userText) {
+  // discord.js guarantees author.username exists, but guildMember +
+  // globalName can be undefined in edge cases (DMs, uncached members).
+  // Final fallback is a generic literal to prevent `<sender name="undefined"/>`.
   const username =
-    message.member?.displayName || message.author.globalName || message.author.username;
+    message.member?.displayName ||
+    message.author.globalName ||
+    message.author.username ||
+    "使用者";
   // 使用 XML 風格的 metadata 包裝，避免 LLM 把「name: text」當 dialogue 模板
   // 學會在自己的回應裡也加 name 前綴。
   return userText
@@ -1405,6 +1411,10 @@ async function callGemini(turns) {
       body: JSON.stringify(body),
       signal,
     });
+
+    // Note: Gemini uses URL query-string auth (`?key=...`) and doesn't return
+    // x-ratelimit-* headers like Groq / Cerebras / DeepSeek do, so we skip
+    // logRateHeaders() here — there's nothing useful to log.
 
     if (!response.ok) {
       const errText = await response.text().catch(() => "");
@@ -1636,6 +1646,12 @@ async function generateAIReply(message, userText) {
       return trimmed;
     }
   }
+  // All providers returned null (HTTP errors, safety blocks, timeouts, etc.).
+  // Individual failures already logged inside each callXxx; this single line
+  // makes "everything failed" easy to grep for in ops.
+  console.warn(
+    `[ai] chain exhausted (${AI_PROVIDER_CHAIN.length} providers tried), falling back to hardcoded reply`,
+  );
   return null;
 }
 
@@ -1758,8 +1774,22 @@ client.on("messageCreate", async (message) => {
   }
 });
 
+// Background cleanup tasks: the per-read lazy cleanup in
+// `cleanupAIConversationHistory` only evicts when a channel is active.
+// A silent channel (no @ for >30min) would linger in RAM forever on a
+// long-running multi-guild bot. Periodic sweep covers that.
+const AI_MEMORY_SWEEP_INTERVAL_MS = Math.max(60_000, Math.floor(AI_MEMORY_TTL_MS / 4));
+const aiMemorySweepTimer = setInterval(() => {
+  cleanupAIConversationHistory();
+}, AI_MEMORY_SWEEP_INTERVAL_MS);
+// Don't block process exit on this timer (it's a janitor, not critical work).
+if (typeof aiMemorySweepTimer.unref === "function") {
+  aiMemorySweepTimer.unref();
+}
+
 for (const signal of ["SIGINT", "SIGTERM"]) {
   process.once(signal, () => {
+    clearInterval(aiMemorySweepTimer);
     process.exit(0);
   });
 }


### PR DESCRIPTION
## 動機
PR #6/#7/#8 累積後做一次 audit：用 Explore agent code review + 文件對齊。

## Code 修了什麼
| # | 修 | 為什麼 |
|---|---|---|
| 1 | `aiConversationHistory` 加**背景 cleanup 定時器** | 原本只在 `getChannelAIHistory` 被呼叫時才 evict。安靜的 channel 會永遠留在 RAM。加 setInterval（每 `TTL/4` 一次），timer `.unref()` 不擋 exit |
| 2 | `buildUserTurn` 給 username 加 fallback `"使用者"` | 防 `<sender name=\"undefined\"/>` 漏進 prompt |
| 3 | 全部 provider 都回 null 時加 `[ai] chain exhausted` log | ops 能一眼看到 AI 全掛 |
| 4 | `callGemini` 加註解解釋為何不呼叫 `logRateHeaders` | Gemini 用 URL query-string 認證、沒 rate-limit header |

## Docs 對齊
- **CLAUDE.md**
  - 補上 `FIXER_INSTAGRAM_SECONDARY` / `FIXER_THREADS_SECONDARY`（code 有用、表格沒列）
  - 記錄 mention-dedup 機制（`inFlightReplies` key=`mention:msgId`）
  - 列出 A~G persona 分類 + A+ 深度題放寬到 5-6 句
  - 記錄 chain-exhausted log
  - 記錄雙路徑清理（lazy + scheduled）
  - 新增 **Production deployment** 章節，記錄 SSH host 部署方式
- **README.md**
  - 4.18 更新釋出說明（DeepSeek 加入、短期記憶、persona v6、雙回應 bug 修復）
  - Features 清單提到所有四個 provider + 短期記憶

## 跳過的 review 項目（確認不是 bug）
- `checkAndHandleEmptyEmbeds` 的 `.catch()` 其實會接到整個 async 函式內的所有 rejection（Explore agent 誤判）
- Cerebras 單獨 retry queue_exceeded 是**刻意設計**（只有它有 shared queue 問題）
- 廢棄 env alias（`GEMINI_TIMEOUT_MS`）仍留作向後相容，不需 deprecation warn（這個專案沒其他 deployer）

## Test plan
- [ ] Lab bot 重啟後看 log，應該看到 `[ai] chain=...` 跟過去一致
- [ ] 等 30+ 分鐘、讓某頻道沒 @ 後，確認背景 cleanup 有 evict（可臨時把 AI_MEMORY_SWEEP_INTERVAL_MS 設小測）
- [ ] 強制製造 chain 全爆（改錯所有 API key），確認有 `[ai] chain exhausted` 一行 log

🤖 Generated with [Claude Code](https://claude.com/claude-code)