### PR TITLE
chore: harden .gitignore (.env backups, *.log)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 node_modules/
 .env
+.env.*
+!.env.example
 .DS_Store
 npm-debug.log*
 start-bot.command
 stop-bot.command
+bot.log
+*.log
+


### PR DESCRIPTION
## Why
使用者提醒：確保 runtime / 個人資料類檔案不會意外 PR 到 GitHub。
Memory 檔本來就在 \`~/.claude/\` 不在 repo 裡，安全；但 repo 內可能有：
- \`.env.bak\` — 換 key 時的備份
- \`bot.log\` — 本機或 deploy host 用 \`nohup ... > bot.log\` 產生

## Changes
```diff
  .env
+ .env.*
+ !.env.example
  ...
+ bot.log
+ *.log
```

## Test plan
- [ ] \`git status\` 看 \`.env.bak\` 沒被追蹤（確認本機 .env.bak 會被忽略）
- [ ] \`cat .gitignore\` 看新規則

🤖 Generated with [Claude Code](https://claude.com/claude-code)