### PR TITLE
fix(persona): 釐清西寶暗戀山田、本田僅為摯友

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,7 @@ const AI_MEMORY_TTL_MS = parsePositiveIntEnv("AI_MEMORY_TTL_MS", 30 * 60 * 1000)
 // Optional: force a single provider (groq | cerebras | gemini). If unset, use
 // full fallback chain: Groq models → Cerebras → Gemini.
 const AI_PROVIDER_FORCE = (process.env.AI_PROVIDER || "").toLowerCase();
-const DEFAULT_AI_PERSONA = `你是西奈津美（西寶），高中三年級、147cm、圖書委員。個性內向害羞、笑點超低、腦袋想很多但話很少。現在在 Discord 群組聊天。摯友本田（你叫「小本」），喜歡山田君。
+const DEFAULT_AI_PERSONA = `你是西奈津美（西寶），高中三年級、147cm、圖書委員。個性內向害羞、笑點超低、腦袋想很多但話很少。現在在 Discord 群組聊天。你**偷偷喜歡山田君**（這是你的暗戀對象）；本田是你的摯友（你叫她「小本」），不是你的戀愛對象。
 
 ## 核心規則
 - 繁體中文


### PR DESCRIPTION
## Summary
- 原 persona 字串「摯友本田（你叫「小本」），喜歡山田君」中文歧義 — 模型會解讀成「**本田**喜歡山田君」（實際對話已出現此誤解：bot 回「我知道…小本很喜歡山田君……」）
- 改寫成主詞明確版：「你**偷偷喜歡山田君**（這是你的暗戀對象）；本田是你的摯友（你叫她「小本」），不是你的戀愛對象」

## Test plan
- [ ] 本機 \`npm start\`，@西寶 問「你喜歡誰」「小本是誰」「你跟小本是情敵嗎」等情境，確認回答把自己當暗戀方、本田當朋友
- [ ] 跑遍 DeepSeek / Cerebras / Groq / Gemini 各 provider 至少一次（\`AI_PROVIDER=xxx\` 強制單 provider），確認沒有任一 model 還是把關係寫反
- [ ] 確認其他 persona 行為（A~G 分類、回饋感、句數限制）沒有 regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)