### PR TITLE
feat(threads): multi-image 優先於 video 判斷，probe 限定主貼文範圍

### DIFF
--- a/.claude/rules/routing.md
+++ b/.claude/rules/routing.md
@@ -5,9 +5,9 @@
 | Condition | Output |
 |---|---|
 | No image (`isTextOnly`) or `twitterCard === "summary"` | Custom embed (text only) |
+| Multiple images (`imageCount > 1`) | Multi-image carousel embed (checked *before* video so mixed image+video posts still show all images) |
 | Has video / `videoCount > 0` | Fixer link (`FIXER_THREADS`) |
 | `summary_large_image` + single image | Custom embed with image |
-| Multiple images (`imageCount > 1`) | Custom embed with image + "Open on Threads" button |
 | Fallback / probe error | Fixer link (`FIXER_THREADS`) |
 
 **Order is load-bearing.** See code in [src/index.js](../../src/index.js) around the Threads routing block — the `if` ladder order determines which branch a mixed (image+video) post falls into.

--- a/src/index.js
+++ b/src/index.js
@@ -910,6 +910,29 @@ async function buildPreviewPayloads(urls) {
         continue;
       }
 
+      if (metadata.imageCount > 1) {
+        const allImages = metadata.images && metadata.images.length > 1
+          ? metadata.images.slice(0, 10)
+          : null;
+        const hasVideo = metadata.video || metadata.videoCount > 0;
+
+        if (allImages) {
+          console.log(`[preview] threads-multi-image carousel count=${allImages.length} hasVideo=${hasVideo} ${url}`);
+          const firstEmbed = buildThreadsMediaEmbed(url, { ...metadata, image: allImages[0] });
+          const restEmbeds = allImages.slice(1).map((imgUrl) =>
+            new EmbedBuilder().setURL(url).setImage(imgUrl).setColor(THREADS_EMBED_COLOR)
+          );
+          payloads.push({ embeds: [firstEmbed, ...restEmbeds] });
+        } else {
+          console.log(`[preview] threads-multi-image fallback hasVideo=${hasVideo} ${url}`);
+          payloads.push({
+            embeds: [buildThreadsMediaEmbed(url, metadata)],
+            components: [buildThreadsLinkRow(url)],
+          });
+        }
+        continue;
+      }
+
       if (metadata.video || metadata.videoCount > 0) {
         console.log(`[preview] threads-video fixer ${url}`);
         const videoFallbackEmbed = buildThreadsCompactEmbed(url, metadata);
@@ -935,28 +958,6 @@ async function buildPreviewPayloads(urls) {
       ) {
         console.log(`[preview] threads-single-image ${url}`);
         payloads.push({ embeds: [buildThreadsMediaEmbed(url, metadata)] });
-        continue;
-      }
-
-      if (metadata.imageCount > 1) {
-        const allImages = metadata.images && metadata.images.length > 1
-          ? metadata.images.slice(0, 10)
-          : null;
-
-        if (allImages) {
-          console.log(`[preview] threads-multi-image carousel count=${allImages.length} ${url}`);
-          const firstEmbed = buildThreadsMediaEmbed(url, { ...metadata, image: allImages[0] });
-          const restEmbeds = allImages.slice(1).map((imgUrl) =>
-            new EmbedBuilder().setURL(url).setImage(imgUrl).setColor(THREADS_EMBED_COLOR)
-          );
-          payloads.push({ embeds: [firstEmbed, ...restEmbeds] });
-        } else {
-          console.log(`[preview] threads-multi-image fallback ${url}`);
-          payloads.push({
-            embeds: [buildThreadsMediaEmbed(url, metadata)],
-            components: [buildThreadsLinkRow(url)],
-          });
-        }
         continue;
       }
 

--- a/src/threads-probe.cjs
+++ b/src/threads-probe.cjs
@@ -107,12 +107,21 @@ async function readThreadsMetadata(page) {
         return src && rect.width >= 160 && rect.height >= 160;
       });
 
-      const candidateVideos = Array.from(document.querySelectorAll("video"));
+      const inMainPost = (element) => {
+        const rect = element.getBoundingClientRect();
+        if (rect.top >= viewportHeight) return false;
+        return rect.width >= 160 && rect.height >= 160;
+      };
+
+      const candidateVideos = Array.from(
+        mediaContainer.querySelectorAll("video"),
+      ).filter(inMainPost);
       const videoPlayerMarkers = Array.from(
-        document.querySelectorAll('[role="group"], [aria-label]'),
+        mediaContainer.querySelectorAll('[role="group"], [aria-label]'),
       ).filter((element) => {
         const ariaLabel = element.getAttribute("aria-label") || "";
-        return ariaLabel.toLowerCase().includes("video player");
+        if (!ariaLabel.toLowerCase().includes("video player")) return false;
+        return inMainPost(element);
       });
 
       return {


### PR DESCRIPTION
## Summary
- **buildPreviewPayloads**: `imageCount > 1` 分支搬到 video 判斷之前。混合 image+video 貼文（多圖中夾雜 video 的）原本只會走 video fixer 拿到一張預覽，現在會走 carousel 把所有圖列出來。多 log 一個 \`hasVideo\` 旗標方便排查
- **threads-probe.cjs**: video 偵測範圍從 \`document\` 縮到主貼文 \`mediaContainer\`，並加 \`inMainPost\` 大小/位置 filter（width/height ≥160 且在 viewport 上半）。修掉「sidebar 相關推薦影片被當成主貼文有影片」的 false positive
- **CLAUDE.md**: routing 表格同步新順序，加註 mixed image+video 行為

## Test plan
- [ ] 純多圖 Threads 貼文 → 走 carousel，所有圖出現
- [ ] 純影片 Threads 貼文 → 走 fixer link
- [ ] 多圖中夾 video 的混合貼文 → 走 carousel（不走 video fixer），log 顯示 \`hasVideo=true\`
- [ ] 純文字 / single-image Threads 貼文 → 行為不變
- [ ] 看 bot.log \`[preview] threads-multi-image\` 行有 \`hasVideo=\` 欄位
- [ ] 確認 sidebar 影片推薦的單圖貼文不會被誤判成 video（之前的 false positive）

🤖 Generated with [Claude Code](https://claude.com/claude-code)