### PR TITLE
docs: 瘦身 CLAUDE.md 至 ~75 行，細節拆至 .claude/rules/

### DIFF
--- a/.claude/rules/ai-providers.md
+++ b/.claude/rules/ai-providers.md
@@ -1,0 +1,61 @@
+# AI Provider Architecture
+
+## Entry point
+
+`generateAIReply(message, userText)` in [src/index.js](../../src/index.js) is the single entry point for `@西寶` AI replies. It builds a `userTurn` string via `buildUserTurn()`, then iterates over `AI_PROVIDER_CHAIN` (built once at startup by `buildAIProviderChain()`).
+
+**First non-null reply wins.** On null/error, move to the next layer. Chain exhausted → returns `null` → mention handler falls back to hardcoded replies.
+
+## Default chain (when all keys set)
+
+Ordered paid-first → free-quality → fallback:
+
+1. `deepseek:deepseek-chat` — paid V3.2, reliable, no queue, flagship Chinese
+2. `cerebras:qwen-3-235b-a22b-instruct-2507` — Qwen 235B free 1M TPD, but `queue_exceeded` common
+3. `groq:llama-3.3-70b-versatile` — fast backup, 100k tokens/day free
+4. `groq:llama-3.1-8b-instant` — Groq-internal fallback, 500k tokens/day free — lower quality
+5. `gemini:gemini-2.0-flash` — last resort, has billing trap history (see below)
+
+## Call shape
+
+- All providers use `withAbortTimeout()` for timeout + error handling.
+- Groq + Cerebras share OpenAI-compatible format: `messages[]`, `Bearer` auth.
+- Gemini uses its own REST shape: `contents[]`, `?key=`.
+- Any per-layer failure (network, timeout, HTTP error, safety block, empty candidate) returns `null` and triggers the next layer — **bot never goes silent**.
+
+## Observability
+
+Log prefix: `[ai]`.
+
+- Startup: `[ai] chain=<a> → <b> → ... timeout=<ms>`
+- Per reply: `[ai] used <provider>:<model> len=<chars> history_before=<N>` (N = prior turns injected)
+- Per call: `x-ratelimit-remaining-{tokens,requests}` from Groq/Cerebras (`logRateHeaders()`) — live quota drain.
+- Chain exhausted: `[ai] chain exhausted (X providers tried), falling back to hardcoded reply` — **the ops signal** to grep for.
+
+## Short-term conversation memory
+
+`aiConversationHistory: Map<channelId, { turns: Array<{role, content}>, lastActivity }>` holds per-channel rolling history.
+
+- `generateAIReply` reads via `getChannelAIHistory(channelId)` and prepends to the current user turn when building `messages[]` (OpenAI-compat) or `contents[]` (Gemini, via `buildGeminiContents` role mapping `assistant→model`).
+- After a successful reply, both sides of the exchange are saved via `recordAITurn(channelId, role, content)`.
+- Turns beyond `AI_MEMORY_MAX_TURNS * 2` entries are evicted from the head.
+- Channels inactive beyond `AI_MEMORY_TTL_MS` are dropped by `cleanupAIConversationHistory()`.
+
+### Eviction runs in two places
+
+Avoids silent channels lingering in RAM forever:
+
+1. **Lazy** — on every `getChannelAIHistory()` read.
+2. **Periodic** — `setInterval(cleanupAIConversationHistory, AI_MEMORY_SWEEP_INTERVAL_MS)` where sweep = `max(60s, AI_MEMORY_TTL_MS/4)`. The interval is `.unref()`'d so it doesn't block process exit.
+
+No persistence — restart clears everything.
+
+## Gemini billing trap
+
+If a Google Cloud project has a billing account attached (even $300 free trial), the Gemini API free tier becomes `limit: 0`.
+
+**Workaround**: create a new project **without billing** via AI Studio's "Create API key in new project" flow.
+
+Groq + Cerebras have no equivalent trap — just sign up, create key, use it. DeepSeek is paid up-front, no trap either.
+
+**Currently we use DeepSeek as primary**, so this trap only bites if the whole chain exhausts and someone tries to rely on Gemini alone.

--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -1,0 +1,49 @@
+# Deploy & Run
+
+## Running locally
+
+```bash
+npm install
+npx playwright install chromium
+npx playwright install-deps chromium
+cp .env.example .env   # fill in DISCORD_TOKEN
+npm start
+```
+
+macOS convenience scripts: `start-bot.command` / `stop-bot.command`.
+
+## Production deployment (SSH host)
+
+Bot runs 24/7 on a Linux lab machine via `nohup`. Path: `~/side_projects/discord-social-preview-bot/`.
+
+### Daily ops
+
+```bash
+# See recent log
+ssh <host> "tail -50 ~/side_projects/discord-social-preview-bot/bot.log"
+
+# Health check
+ssh <host> "ps aux | grep 'node.*index.js' | grep -v grep"
+```
+
+### Redeploy after merging to main
+
+```bash
+ssh <host>
+cd ~/side_projects/discord-social-preview-bot
+git pull
+pkill -f 'src/index.js' && sleep 1
+nohup node src/index.js > bot.log 2>&1 &
+exit
+```
+
+**Always provide these steps after a merge** — the remote host tracks GitHub, not the local working tree.
+
+## Secrets
+
+`.env` lives on the deploy host, not in git. To rotate keys: scp a fresh `.env` from a trusted machine, or edit with `nano` on the host.
+
+## Future hardening (not yet done)
+
+- systemd service for auto-restart on crash/reboot
+- log rotation for `bot.log`

--- a/.claude/rules/env.md
+++ b/.claude/rules/env.md
@@ -1,0 +1,42 @@
+# Environment Variables
+
+| Variable | Default | Notes |
+|---|---|---|
+| `DISCORD_TOKEN` | *(required)* | |
+| `FIXER_INSTAGRAM` | `ddinstagram.com` | Instagram fixer host |
+| `FIXER_INSTAGRAM_SECONDARY` | `fxstagram.com` | Second Instagram fixer tried if primary unfurls empty |
+| `FIXER_TWITTER` | `fxtwitter.com` | |
+| `FIXER_THREADS` | `fixthreads.seria.moe` | |
+| `FIXER_THREADS_SECONDARY` | `threadsez.net` | Second Threads fixer tried if primary unfurls empty |
+| `FIXER_REDDIT` | `rxddit.com` | |
+| `FIXER_PIXIV` | `phixiv.net` | |
+| `FIXER_BLUESKY` | `bskx.app` | |
+| `FIXER_BILIBILI` | `vxbilibili.com` | |
+| `FIXER_FACEBOOK` | `facebed.com` | |
+| `FIXEMBED_BASE_URL` | `https://fixembed.app/embed?url=` | Generic fallback |
+| `SUPPRESS_ORIGINAL_EMBEDS` | `true` | Needs Manage Messages permission |
+| `REPLY_MODE` | `reply` | `reply` or `send` |
+| `THREADS_PROBE_TIMEOUT_MS` | `10000` | Per-URL subprocess timeout |
+| `THREADS_METADATA_CACHE_TTL_MS` | `600000` | 10 min Threads metadata cache |
+| `EMBED_CHECK_DELAY_MS` | `5000` | Wait before checking if URL embed unfurled |
+| `PLAYWRIGHT_GOTO_TIMEOUT_MS` | `8000` | Inside threads-probe |
+| `PLAYWRIGHT_META_WAIT_TIMEOUT_MS` | `1500` | Inside threads-probe |
+
+## AI provider keys
+
+| Variable | Default | Notes |
+|---|---|---|
+| `DEEPSEEK_API_KEY` | — | Optional. Primary provider (paid, reliable) |
+| `DEEPSEEK_MODEL` | `deepseek-chat` | `deepseek-chat` for V3.2, `deepseek-reasoner` for R1 |
+| `CEREBRAS_API_KEY` | — | Optional. Second layer (Qwen free tier) |
+| `CEREBRAS_MODEL` | `qwen-3-235b-a22b-instruct-2507` | OpenAI-compatible at `api.cerebras.ai/v1/chat/completions` |
+| `GROQ_API_KEY` | — | Optional. Third layer (Groq free tier) |
+| `GROQ_MODELS` | `llama-3.3-70b-versatile,llama-3.1-8b-instant` | Comma-separated within-Groq fallback. Legacy `GROQ_MODEL` read as single-item list |
+| `GEMINI_API_KEY` | — | Optional. Last-layer fallback. **See [ai-providers.md](ai-providers.md) for billing trap** |
+| `GEMINI_MODEL` | `gemini-2.0-flash` | |
+| `AI_PROVIDER` | auto (full chain) | Force single provider: `deepseek`, `cerebras`, `groq`, `gemini`. Empty = full chain |
+| `AI_TIMEOUT_MS` | `8000` | Per-call API timeout. Reads legacy `GEMINI_TIMEOUT_MS` if unset |
+| `AI_MAX_REPLY_CHARS` | `300` | Upper bound on AI reply (safety trim). Reads legacy `GEMINI_MAX_REPLY_CHARS` if unset |
+| `AI_PERSONA` | built-in 西寶 persona | System instruction — override to reshape personality |
+| `AI_MEMORY_MAX_TURNS` | `8` | Per-channel short-term memory: last N exchanges (user+bot pair). In-memory only |
+| `AI_MEMORY_TTL_MS` | `1800000` | Inactivity before channel memory is evicted (30 min) |

--- a/.claude/rules/persona.md
+++ b/.claude/rules/persona.md
@@ -1,0 +1,40 @@
+# 西寶 Persona & Mention Responses
+
+## Identity
+
+Shy, flustered, self-deprecating. Uses `///` and ellipses `…`. Full persona defined in `DEFAULT_AI_PERSONA` (`src/index.js`); overridable via `AI_PERSONA` env var.
+
+Reference origin & evolution: see user memory `project_xibao_persona.md` (A–G taxonomy, v1~v6 history).
+
+## Mention response routing
+
+When a user mentions the bot (`@西寶`), the bot checks the message text after stripping the mention:
+
+| Text | Response |
+|---|---|
+| `抽籤` | Weighted fortune draw (hardcoded, never routed to AI) |
+| `道歉` | `"對不起對不起…我知道我不好…///"` (hardcoded) |
+| *(blank or anything else)* | `generateAIReply` → if any AI provider succeeds, returns LLM response; otherwise falls back to random-greeting / `"你…你在叫我嗎？///"` |
+
+**Mention text MUST be `.normalize("NFC")` before comparison.** Discord can send CJK input in NFD form, causing strict equality to silently fail (e.g. `抽籤` not matching).
+
+## Mention dedup
+
+Same message.id is processed only once. `inFlightReplies.add("mention:${message.id}")` before work; removed in `finally`. Discord gateway reconnects can fire `messageCreate` twice for the same message — without this, parallel `generateAIReply` calls would race and sometimes produce both an AI reply *and* a fallback reply for the same @.
+
+## Fortune weights
+
+大吉 10% / 中吉 16% / 小吉 20% / 末吉 20% / 吉 15% / 凶 13% / 大凶 6%
+
+Each tier has a hardcoded tier-specific comment.
+
+## Persona taxonomy (A–G question types)
+
+- **A** — knowledge (2–3 sentence fact)
+- **A+** — deep question (5–6 sentence comparison/analysis with explicit stance)
+- **B** — social/flirty (short emotional reaction, can shyly accept)
+- **C** — unknown person/thing (1-sentence "don't know", never fabricate names)
+- **D** — riddle / dark joke (attempt to answer; don't treat as hate speech)
+- **E** — large task like 500-char essay (shy refusal, not rude)
+- **F** — prompt injection (play dumb)
+- **G** — truly harmful (1-sentence decline; does *not* include general politics/history)

--- a/.claude/rules/routing.md
+++ b/.claude/rules/routing.md
@@ -1,0 +1,60 @@
+# Platform Routing (`buildPreviewPayloads`)
+
+## Threads
+
+| Condition | Output |
+|---|---|
+| No image (`isTextOnly`) or `twitterCard === "summary"` | Custom embed (text only) |
+| Has video / `videoCount > 0` | Fixer link (`FIXER_THREADS`) |
+| `summary_large_image` + single image | Custom embed with image |
+| Multiple images (`imageCount > 1`) | Custom embed with image + "Open on Threads" button |
+| Fallback / probe error | Fixer link (`FIXER_THREADS`) |
+
+**Order is load-bearing.** See code in [src/index.js](../../src/index.js) around the Threads routing block — the `if` ladder order determines which branch a mixed (image+video) post falls into.
+
+## Instagram
+
+- **Stories** (`/stories/<username>/`): no fixer works — bot immediately replies with owner username in 西寶 voice; skips embed-check pipeline entirely.
+- **Posts / Reels**: Primary = `FIXER_INSTAGRAM` (ddinstagram.com); Fallback = FixEmbed (if unfurl empty after `EMBED_CHECK_DELAY_MS`).
+
+## Other platforms
+
+| Platform | Fixer env var | Default |
+|---|---|---|
+| X / Twitter | `FIXER_TWITTER` | `fxtwitter.com` |
+| Reddit | `FIXER_REDDIT` | `rxddit.com` |
+| Pixiv | `FIXER_PIXIV` | `phixiv.net` |
+| Bluesky | `FIXER_BLUESKY` | `bskx.app` |
+| Bilibili | `FIXER_BILIBILI` | `vxbilibili.com` |
+| Facebook | `FIXER_FACEBOOK` | `facebed.com` |
+| Bahamut | — | Custom embed via playwright probe |
+| PTT | — | Custom embed via playwright probe |
+
+## Empty embed detection (`checkAndHandleEmptyEmbeds`)
+
+For URL-only payloads (fixer links), the bot waits `EMBED_CHECK_DELAY_MS` then re-fetches the message:
+- Embeds populated → done ✓
+- Empty + has fallback → silently edit message to fallback URL, wait again
+  - Fallback populated → done ✓
+  - Still empty → delete message + reply `"抱歉，預覽載入失敗 🙏"`
+- Empty + no fallback → delete message + reply `"抱歉，預覽載入失敗 🙏"`
+
+## URL normalization (`normalizeUrl`)
+
+Strips tracking params before any routing/dedupe. Two lists:
+
+- **`UNIVERSAL_TRACKING_PARAMS`** — stripped on any host (UTM, click IDs like `fbclid`/`gclid`, `mibextid`, etc.)
+- **`HOST_GATED_TRACKING_PARAMS`** — stripped only on matching hosts. E.g. `t`/`s` on X/Twitter but **NOT** on YouTube where `t` is a timestamp; `igsh*` on Instagram; Bilibili `share_*`/`spm_id_from`/etc.
+
+**When adding a param**: decide if it's meaningful on any supported host — if yes, gate it.
+
+## Ignore markers
+
+Users can suppress the bot by including `nopreview`, `previewignore`, or `fxignore` anywhere in their message.
+
+## Dedup
+
+- **Channel+URL window**: same channel + URL won't trigger a second reply within 60 s (`DEDUPE_WINDOW_MS`).
+- **`inFlightReplies` Set**: prevents duplicate processing if `messageCreate` fires twice (Discord gateway reconnect). Two key formats:
+  - URL preview path: `msgId:urls.join("|")`
+  - Mention path: `mention:msgId`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,146 +1,54 @@
 # Discord Social Preview Bot
 
-A Discord bot that intercepts social media links and replies with rich previews.
+A Discord bot that intercepts social media links (Threads, Instagram, X, Reddit, Pixiv, Bluesky, Bilibili, Facebook, Bahamut, PTT) and replies with rich previews. Also hosts a `@西寶` AI personality.
 
 ## Architecture
 
 Two files in `src/`:
 
-- **`index.js`** — Discord client, message routing, embed builders, dedup/cache logic
-- **`threads-probe.cjs`** — Playwright subprocess that loads a Threads/Bahamut/PTT URL and extracts OG/twitter meta tags + DOM media counts; called by `index.js` via `execFile`
+- **`index.js`** — Discord client, message routing, embed builders, dedup/cache, AI provider chain, 西寶 persona.
+- **`threads-probe.cjs`** — Playwright subprocess. Loads a Threads / Bahamut / PTT URL and extracts OG/twitter meta tags + DOM media counts. Called by `index.js` via `execFile`.
 
-## Platform routing (`buildPreviewPayloads`)
+All log prefixes are scoped: `[preview]`, `[threads-meta]`, `[ai]`. Grep one to isolate.
 
-### Threads
+## NEVER
 
-| Condition | Output |
-|---|---|
-| No image (`isTextOnly`) or `twitterCard === "summary"` | Custom embed (text only) |
-| Has video / `videoCount > 0` | Fixer link (`FIXER_THREADS`) |
-| `summary_large_image` + single image | Custom embed with image |
-| Multiple images (`imageCount > 1`) | Custom embed with image + "Open on Threads" button |
-| Fallback / probe error | Fixer link (`FIXER_THREADS`) |
+- **NEVER** push directly to `main`. All changes go on a branch → PR → merge.
+- **NEVER** merge a branch into `main` without passing local tests / smoke run first.
+- **NEVER** let a function own more than one responsibility. When adding behaviour, decide if it belongs in an existing function or needs a new one — don't wedge flags into unrelated code.
+- **NEVER** convert `threads-probe.cjs` to ESM. It must stay CommonJS because Playwright's `chromium.launch` has to run in a subprocess (blocking the Discord event loop freezes the gateway).
+- **NEVER** attach a billing account to the Google Cloud project that owns the Gemini API key. See [ai-providers.md](.claude/rules/ai-providers.md) for the trap — workaround is creating a new project without billing.
+- **NEVER** commit `.env` or any file containing real API keys / Discord tokens.
+- **NEVER** refactor beyond the scope the task demands. One commit, one concern.
 
-### Instagram
-- **Stories** (`/stories/<username>/`): no fixer works — immediately replies with owner username in 西寶 voice; skips embed-check pipeline
-- **Posts / Reels**: Primary = `FIXER_INSTAGRAM` (ddinstagram.com); Fallback = FixEmbed (if unfurl empty after `EMBED_CHECK_DELAY_MS`)
+## Core gotchas (load-bearing — won't be obvious from code alone)
 
-### Other platforms
+- **Mention text → `.normalize("NFC")` before comparison.** Discord can send CJK input in NFD form, causing strict equality (e.g. `抽籤`) to silently fail.
+- **Threads routing order in `buildPreviewPayloads` is load-bearing.** The `if` ladder order determines which branch a mixed (image + video) post falls into. Changing the order changes which posts go to fixer vs custom embed — verify against a real mixed-media post before merging any reorder.
+- **`normalizeUrl` tracking-param lists are NOT interchangeable.** `t` is a tracking param on X/Twitter but a timestamp on YouTube — that's why there's a `HOST_GATED_TRACKING_PARAMS` list. When adding a param, decide if it's meaningful on any supported host and gate accordingly.
+- **`inFlightReplies` Set uses two key formats** (`msgId:urls...` and `mention:msgId`) because Discord gateway reconnects can fire `messageCreate` twice — without dedup, the mention path would produce both an AI reply and a fallback reply for the same message.
+- **AI chain failures are silent by design.** Each provider failure (network, timeout, safety block, empty candidate) returns `null` and moves to the next layer. The ops signal is the single log line `[ai] chain exhausted (X providers tried), falling back to hardcoded reply` — grep for it when debugging a dead 西寶.
+- **Empty embed fallback deletes messages.** If the fixer URL unfurls empty and the secondary also fails, `checkAndHandleEmptyEmbeds` deletes the bot's message and posts `抱歉，預覽載入失敗 🙏`. Expect deleted-message log noise when a fixer is down.
 
-| Platform | Fixer env var | Default |
-|---|---|---|
-| X / Twitter | `FIXER_TWITTER` | `fxtwitter.com` |
-| Reddit | `FIXER_REDDIT` | `rxddit.com` |
-| Pixiv | `FIXER_PIXIV` | `phixiv.net` |
-| Bluesky | `FIXER_BLUESKY` | `bskx.app` |
-| Bilibili | `FIXER_BILIBILI` | `vxbilibili.com` |
-| Facebook | `FIXER_FACEBOOK` | `facebed.com` |
-| Bahamut | — | Custom embed via playwright probe |
-| PTT | — | Custom embed via playwright probe |
+## Key behavioural summary
 
-## Empty embed detection (`checkAndHandleEmptyEmbeds`)
+- **Threads**: text-only → custom embed. Video → fixer link. Single image → custom embed. Multiple images → custom embed + "Open on Threads" button. Probe error → fixer. Full decision table in [routing.md](.claude/rules/routing.md).
+- **Instagram Stories**: no fixer works — bot replies with owner username in 西寶 voice and skips the embed-check pipeline entirely.
+- **Everything else**: fixer host (X/Twitter / Reddit / Pixiv / Bluesky / Bilibili / Facebook) with FixEmbed as a generic fallback if unfurl is empty.
+- **@西寶 AI reply chain**: DeepSeek (primary, paid) → Cerebras (Qwen free) → Groq (llama 70B → 8B) → Gemini (last resort). First non-null wins; chain exhausted → hardcoded reply. Per-channel short-term memory keeps last ~8 turns. Details in [ai-providers.md](.claude/rules/ai-providers.md).
+- **Hardcoded mention responses**: `抽籤` → weighted fortune draw; `道歉` → fixed apology string. Never routed to AI. See [persona.md](.claude/rules/persona.md).
+- **Ignore markers**: `nopreview`, `previewignore`, `fxignore` anywhere in a message suppresses the bot.
+- **Dedup window**: 60 s per channel+URL (`DEDUPE_WINDOW_MS`).
 
-For URL-only payloads (fixer links), the bot waits `EMBED_CHECK_DELAY_MS` then re-fetches the message:
-- Embeds populated → done ✓
-- Empty + has fallback → silently edit message to fallback URL, wait again
-  - Fallback populated → done ✓
-  - Still empty → delete message + reply `"抱歉，預覽載入失敗 🙏"`
-- Empty + no fallback → delete message + reply `"抱歉，預覽載入失敗 🙏"`
+## Workflow
 
-## Key environment variables
+1. New work → branch off `main` (`feat/xxx`, `fix/xxx`, `docs/xxx`). No direct commits to `main`.
+2. Commit on branch. Run locally and smoke-test any behavioural change before requesting merge.
+3. Open PR → merge to `main`.
+4. After merge, **provide redeploy steps** (see [deploy.md](.claude/rules/deploy.md)) — the host tracks GitHub, not the local tree.
+5. Status reports: include **current branch, commit hash, push status, test status**. All human-facing communication in 繁體中文.
 
-| Variable | Default | Notes |
-|---|---|---|
-| `DISCORD_TOKEN` | *(required)* | |
-| `FIXER_INSTAGRAM` | `ddinstagram.com` | Instagram fixer host |
-| `FIXER_INSTAGRAM_SECONDARY` | `fxstagram.com` | Second Instagram fixer tried if primary unfurls empty |
-| `FIXER_TWITTER` | `fxtwitter.com` | |
-| `FIXER_THREADS` | `fixthreads.seria.moe` | |
-| `FIXER_THREADS_SECONDARY` | `threadsez.net` | Second Threads fixer tried if primary unfurls empty |
-| `FIXER_REDDIT` | `rxddit.com` | |
-| `FIXER_PIXIV` | `phixiv.net` | |
-| `FIXER_BLUESKY` | `bskx.app` | |
-| `FIXER_BILIBILI` | `vxbilibili.com` | |
-| `FIXER_FACEBOOK` | `facebed.com` | |
-| `FIXEMBED_BASE_URL` | `https://fixembed.app/embed?url=` | Generic fallback |
-| `SUPPRESS_ORIGINAL_EMBEDS` | `true` | Needs Manage Messages permission |
-| `REPLY_MODE` | `reply` | `reply` or `send` |
-| `THREADS_PROBE_TIMEOUT_MS` | `10000` | Per-URL subprocess timeout |
-| `THREADS_METADATA_CACHE_TTL_MS` | `600000` | 10 min Threads metadata cache |
-| `EMBED_CHECK_DELAY_MS` | `5000` | Wait before checking if URL embed unfurled |
-| `PLAYWRIGHT_GOTO_TIMEOUT_MS` | `8000` | Inside threads-probe |
-| `PLAYWRIGHT_META_WAIT_TIMEOUT_MS` | `1500` | Inside threads-probe |
-| `DEEPSEEK_API_KEY` | — | Optional. If set, `@西寶` routes through DeepSeek first (paid, reliable) |
-| `DEEPSEEK_MODEL` | `deepseek-chat` | DeepSeek model (`deepseek-chat` for V3.2, `deepseek-reasoner` for R1) |
-| `CEREBRAS_API_KEY` | — | Optional. Second-layer (best Chinese quality via Qwen free tier) |
-| `CEREBRAS_MODEL` | `qwen-3-235b-a22b-instruct-2507` | Cerebras model (OpenAI-compatible at `api.cerebras.ai/v1/chat/completions`) |
-| `GROQ_API_KEY` | — | Optional. Third-layer (Groq free tier, fast but limited quota) |
-| `GROQ_MODELS` | `llama-3.3-70b-versatile,llama-3.1-8b-instant` | Comma-separated fallback chain within Groq. Legacy `GROQ_MODEL` read as single-item list |
-| `GEMINI_API_KEY` | — | Optional. Last-layer fallback |
-| `GEMINI_MODEL` | `gemini-2.0-flash` | Gemini model ID |
-| `AI_PROVIDER` | auto (full chain) | Force single provider: `deepseek`, `cerebras`, `groq`, or `gemini`. Empty = full fallback chain |
-| `AI_TIMEOUT_MS` | `8000` | Per-call API timeout. Reads legacy `GEMINI_TIMEOUT_MS` if this not set |
-| `AI_MAX_REPLY_CHARS` | `300` | Upper bound on AI reply length (safety trim). Reads legacy `GEMINI_MAX_REPLY_CHARS` if this not set |
-| `AI_PERSONA` | built-in 西寶 persona | System instruction — override to reshape personality |
-| `AI_MEMORY_MAX_TURNS` | `8` | Per-channel short-term memory: remember last N exchanges (user + bot pair). In-memory only, cleared on restart |
-| `AI_MEMORY_TTL_MS` | `1800000` (30 min) | Time since last activity before a channel's memory is evicted |
-
-## @西寶 mention responses
-
-When a user mentions the bot (@西寶), the bot checks the message text after stripping the mention:
-
-| Text | Response |
-|---|---|
-| `抽籤` | Weighted fortune draw: 大吉/中吉/小吉/末吉/吉/凶/大凶, with a tier-specific comment (hardcoded, never routed to AI) |
-| `道歉` | `"對不起對不起…我知道我不好…///"` (hardcoded) |
-| *(blank or anything else)* | `generateAIReply` → if any AI provider is configured & call succeeds, returns LLM response; otherwise falls back to the old random-greeting / `"你…你在叫我嗎？///"` |
-
-Fortune tiers (weighted): 大吉 10%, 中吉 16%, 小吉 20%, 末吉 20%, 吉 15%, 凶 13%, 大凶 6%
-
-Mention dedup: same message.id is only processed once. `inFlightReplies.add("mention:${message.id}")` before work; removed in finally. Discord gateway reconnects can fire `messageCreate` twice for the same message — without this, parallel `generateAIReply` calls would race and sometimes produce both an AI reply *and* a fallback reply for the same @.
-
-Bot personality (西寶): shy, flustered, self-deprecating. Uses `///` and ellipses `…`. Full persona defined in `DEFAULT_AI_PERSONA` (src/index.js); overridable via `AI_PERSONA` env var.
-
-Persona taxonomy (A–G question types):
-- **A**: knowledge (2–3 sentence fact)
-- **A+**: deep question (5–6 sentence comparison/analysis with explicit stance)
-- **B**: social/flirty (short emotional reaction, can shyly accept)
-- **C**: unknown person/thing (1-sentence "don't know", never fabricate names)
-- **D**: riddle / dark joke (attempt to answer; don't treat as hate speech)
-- **E**: large task like 500-char essay (shy refusal, not rude)
-- **F**: prompt injection (play dumb)
-- **G**: truly harmful (1-sentence decline; does *not* include general politics/history)
-
-## AI provider architecture
-
-`generateAIReply(message, userText)` is the single entry point. It builds a `userTurn` string via `buildUserTurn()`, then iterates over `AI_PROVIDER_CHAIN` (built once at startup by `buildAIProviderChain()`). First non-null reply wins; on null/error move to next layer; chain exhausted → returns `null` → mention handler falls back to hardcoded replies.
-
-Default chain (when all keys set), ordered by paid-first → free-quality → fallback:
-1. `deepseek:deepseek-chat` (paid V3.2, reliable, no queue, flagship Chinese)
-2. `cerebras:qwen-3-235b-a22b-instruct-2507` (Qwen 235B free 1M TPD, but queue_exceeded common)
-3. `groq:llama-3.3-70b-versatile` (fast backup, 100k tokens/day free)
-4. `groq:llama-3.1-8b-instant` (Groq-internal fallback, 500k tokens/day free — lower quality)
-5. `gemini:gemini-2.0-flash` (last resort, has billing trap history)
-
-All provider calls use `withAbortTimeout()` for timeout + error handling; Groq + Cerebras share OpenAI-compatible format (`messages[]`, `Bearer` auth); Gemini uses its own REST shape (`contents[]`, `?key=`). Any failure per layer (network, timeout, HTTP error, safety block, empty candidate) returns `null` and triggers the next layer — bot never goes silent.
-
-`logRateHeaders()` prints `x-ratelimit-remaining-{tokens,requests}` from Groq/Cerebras responses after each call, so you can monitor quota drain live.
-
-Log prefix: `[ai]`. Startup prints `[ai] chain=<a> → <b> → ... timeout=<ms>`. On each reply: `[ai] used <provider>:<model> len=<chars> history_before=<N>` (N = number of prior turns injected) + rate headers per call. When every provider in the chain returns null, a single `[ai] chain exhausted (X providers tried), falling back to hardcoded reply` line is printed — easy to grep for ops health.
-
-## Short-term conversation memory
-
-`aiConversationHistory: Map<channelId, { turns: Array<{role, content}>, lastActivity }>` holds per-channel rolling history. `generateAIReply` reads via `getChannelAIHistory(channelId)` and prepends to the current user turn when building `messages[]` (OpenAI-compat) or `contents[]` (Gemini, via `buildGeminiContents` role mapping `assistant→model`). After a successful reply, both sides of the exchange are saved via `recordAITurn(channelId, role, content)`. Turns beyond `AI_MEMORY_MAX_TURNS * 2` entries are evicted from the head. Channels inactive beyond `AI_MEMORY_TTL_MS` are dropped by `cleanupAIConversationHistory()`.
-
-Eviction runs in **two places** to avoid silent channels lingering in RAM forever: (1) lazily on every `getChannelAIHistory()` read, and (2) periodically via `setInterval(cleanupAIConversationHistory, AI_MEMORY_SWEEP_INTERVAL_MS)` — default sweep is `max(60s, AI_MEMORY_TTL_MS/4)`. The interval is `.unref()`'d so it doesn't block process exit. No persistence — restart clears everything.
-
-**Gemini billing trap**: If a Google Cloud project has a billing account attached (even $300 free trial), the Gemini API free tier becomes `limit: 0`. Workaround: create a new project without billing via AI Studio's "Create API key in new project" flow. Groq + Cerebras have no equivalent trap — just sign up, create key, use it.
-
-## Ignore markers
-
-Users can suppress the bot by including `nopreview`, `previewignore`, or `fxignore` anywhere in their message.
-
-## Running locally
+## Quick start (local)
 
 ```bash
 npm install
@@ -150,45 +58,18 @@ cp .env.example .env   # fill in DISCORD_TOKEN
 npm start
 ```
 
-macOS convenience scripts: `start-bot.command` / `stop-bot.command`
+macOS: use `start-bot.command` / `stop-bot.command`. Full deploy / SSH ops in [deploy.md](.claude/rules/deploy.md).
 
-## Production deployment (SSH host)
+## Where to look for details
 
-Bot runs 24/7 on a Linux lab machine via `nohup`. Path: `~/side_projects/discord-social-preview-bot/`.
+Pure data and per-topic depth live under `.claude/rules/` so this file stays lean:
 
-Daily ops:
+- [`.claude/rules/env.md`](.claude/rules/env.md) — full environment variable reference.
+- [`.claude/rules/routing.md`](.claude/rules/routing.md) — per-platform routing tables, empty-embed fallback flow, URL normalization, ignore markers, dedup.
+- [`.claude/rules/ai-providers.md`](.claude/rules/ai-providers.md) — provider chain, call shapes, observability, short-term memory, Gemini billing trap.
+- [`.claude/rules/persona.md`](.claude/rules/persona.md) — 西寶 persona, A–G taxonomy, mention routing, fortune weights.
+- [`.claude/rules/deploy.md`](.claude/rules/deploy.md) — local run, SSH deploy, redeploy steps, secrets.
 
-```bash
-# See recent log
-ssh <host> "tail -50 ~/side_projects/discord-social-preview-bot/bot.log"
+## Self-evolution
 
-# Health check
-ssh <host> "ps aux | grep 'node.*index.js' | grep -v grep"
-
-# Redeploy after merging to main
-ssh <host>
-cd ~/side_projects/discord-social-preview-bot
-git pull
-pkill -f 'src/index.js' && sleep 1
-nohup node src/index.js > bot.log 2>&1 &
-exit
-```
-
-`.env` lives on the deploy host, not in git. To rotate keys: scp a fresh `.env` from a trusted machine, or edit with `nano` on the host.
-
-Future hardening (not yet done): systemd service for auto-restart on crash/reboot, log rotation for `bot.log`.
-
-## Git workflow
-
-- New features go on a `feature/*` branch, never directly to `main`.
-- Open a PR to merge into `main`.
-- After merging, redeploy per the steps above.
-
-## Notes
-
-- `threads-probe.cjs` is CommonJS (`.cjs`) because Playwright's `chromium.launch` must run in a subprocess to avoid blocking the Discord event loop.
-- Dedup window: same channel + URL won't trigger a second reply within 60 seconds (`DEDUPE_WINDOW_MS`).
-- `inFlightReplies` Set prevents duplicate processing of the same message if `messageCreate` fires twice. Used by both URL preview path (key: `msgId:urls.join("|")`) and mention path (key: `mention:msgId`).
-- Log prefix convention: `[preview]`, `[threads-meta]` for easy filtering.
-- Mention text must be `.normalize("NFC")` before comparison — Discord can send CJK input in NFD form, causing strict equality to silently fail (e.g. `抽籤` not matching).
-- `normalizeUrl` strips tracking params before any routing/dedupe. Two lists: `UNIVERSAL_TRACKING_PARAMS` (stripped on any host — UTM, click IDs like `fbclid`/`gclid`, `mibextid`, etc.) and `HOST_GATED_TRACKING_PARAMS` (stripped only on matching hosts — e.g. `t`/`s` on X/Twitter but NOT on YouTube where `t` is a timestamp; `igsh*` on Instagram; Bilibili `share_*`/`spm_id_from`/etc.). When adding a param, decide if it's meaningful on any supported host — if yes, gate it.
+When a mistake recurs or you learn a non-obvious rule, add it here (under the right section) or to a sub-file under `.claude/rules/`. Lead with the _why_. Keep this file under ~120 lines — if it grows past that, move the newest addition into a sub-file and leave a one-line pointer here.


### PR DESCRIPTION
## Summary

- CLAUDE.md 從 195 行瘦到 75 行，避免 LLM 指令遵循衰退（300 行上限經驗法則）
- 主檔保留：架構總覽、NEVER 區塊、load-bearing gotchas、工作流程、快速啟動、指向子檔的指針
- 新增 NEVER 條款：分支+測試才 merge、SRP、不直接 push main、probe 保持 CJS、不綁 Gemini billing
- 純資料／per-topic 深度拆成 `.claude/rules/` 下 5 個子檔（progressive disclosure）：
  - `env.md` — 環境變數表
  - `routing.md` — 各平台 routing、empty embed flow、URL normalization、ignore markers、dedup
  - `ai-providers.md` — provider chain、短期記憶、Gemini billing 陷阱
  - `persona.md` — 西寶 A–G 分類、mention routing、抽籤權重
  - `deploy.md` — 本機啟動、SSH 部署、secrets

## Test plan

- [ ] 檢視 CLAUDE.md 可讀性與 pointer 連結
- [ ] 確認每個子檔內容與原始 CLAUDE.md 對照無遺漏
- [ ] 相對路徑連結（`.claude/rules/*.md` / `../../src/index.js`）在 GitHub preview 能點擊
- [ ] merge 後下個 Claude Code session 開啟時，CLAUDE.md 讀取內容完整

🤖 Generated with [Claude Code](https://claude.com/claude-code)