### PR TITLE
docs(readme): 重寫新手安裝流程 + Groq 提前為首選 AI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,233 @@
-# Discord Social Preview Bot
+# Discord Social Preview Bot 
 
 ### 可以在 Discord 預覽社群貼文的機器人！#支援 Threads
 
-4.12 更新：Bilibili、Threads 多圖&影片、IG reels、FB貼文 可以正確顯示（繞過登入要求）
-
-4.15 更新：預覽失敗時會道歉 orz、運勢抽籤
-
-4.17 更新：@西寶 接上 AI，會很害羞地跟你閒聊（需自備 API_KEY，免費）
-
+一個會攔截 Threads / X / Instagram / Reddit / Pixiv / Bluesky / Bilibili / Facebook / 巴哈姆特 / PTT 連結、並回覆完整預覽的 Discord bot。同時附帶一個害羞內向的 AI 人格可以陪聊（預設叫「**西寶**」，可自行改名與換人格，見下方 [@西寶 AI 回覆](#西寶-ai-回覆可選)）。
 
 <img width="609" height="484" alt="image" src="https://github.com/user-attachments/assets/51f4fd21-25cc-4a7d-befb-3c58bd5c9ae8" />
 <img width="514" height="83" alt="image" src="https://github.com/user-attachments/assets/74e30b1e-e0a0-4016-8e4c-5cfc3c838b71" />
 <img width="300" height="88" alt="image" src="https://github.com/user-attachments/assets/963324f8-ed11-4af3-b587-45d617573766" />
 
+**最近更新**
 
+- 4.18：README 重寫新手安裝流程（五分鐘快速安裝）、標註「西寶」為可改的預設名稱、介紹適合串接的 AI
+- 4.17：`@西寶` 接上 AI，會很害羞地跟你閒聊（需自備 API key，可用全免費方案）
+- 4.15：預覽失敗時會道歉 orz、運勢抽籤
+- 4.12：Bilibili、Threads 多圖&影片、IG Reels、FB 貼文 可正確顯示（繞過登入要求）
 
-## Supported platforms
+---
 
-- Threads (`threads.com`, `threads.net`)
-- X / Twitter
-- Instagram
-- Reddit
-- Pixiv
-- Bluesky
-- Bilibili
-- Facebook (`facebook.com`, `m.facebook.com`, `fb.watch`)
-- 巴哈姆特 (`forum.gamer.com.tw`, `m.gamer.com.tw`)
-- PTT (`ptt.cc`, `www.ptt.cc`)
+## 目錄
 
-## Current preview behavior
+- [支援平台](#支援平台)
+- [🍋‍🟩 五分鐘快速安裝](#-五分鐘快速安裝) ← **新手從這裡開始**
+- [@西寶 AI 回覆（可選）](#西寶-ai-回覆可選)
+- [Docker 安裝（替代方案）](#docker-安裝替代方案)
+- [預覽行為詳表](#預覽行為詳表)
+- [其他功能](#其他功能)
+- [疑難排解](#疑難排解)
+- [安全提醒](#安全提醒)
+
+---
+
+## 支援平台
+
+Threads / X (Twitter) / Instagram / Reddit / Pixiv / Bluesky / Bilibili / Facebook / 巴哈姆特 / PTT
+
+> 詳細的貼文類型與預覽方式見下方 [預覽行為詳表](#預覽行為詳表)。
+
+---
+
+## 🍋‍🟩 五分鐘快速安裝
+
+新人第一次安裝 bot，只要跑完這 5 步就會動：
+
+### Step 1：安裝 Node.js 20+
+
+確認版本：
+
+```bash
+node -v
+```
+
+沒裝的話到 [nodejs.org](https://nodejs.org/) 下載 LTS 版本（v20 以上）。
+
+### Step 2：下載專案並安裝依賴
+
+```bash
+git clone https://github.com/Lanternko/discord-social-preview-bot.git
+cd discord-social-preview-bot
+npm install
+npx playwright install chromium
+```
+
+Linux 多加一行（macOS / Windows 跳過）：
+
+```bash
+sudo npx playwright install-deps chromium
+```
+
+### Step 3：建立 Discord Bot 並取得 Token
+
+1. 打開 [Discord Developer Portal](https://discord.com/developers/applications) → **New Application** → 取名
+2. 左側選單 **Bot** → **Reset Token** → 複製 token（這就是之後要填的 `DISCORD_TOKEN`）
+3. 同頁面下方開啟：
+   - ✅ `MESSAGE CONTENT INTENT`（**必開**，否則 bot 看不到訊息內容）
+   - ✅ `PUBLIC BOT`（想讓別人也能邀你的 bot 才需要）
+4. 左側 **Installation** → 勾選 `Guild Install`
+5. 左側 **OAuth2 → URL Generator**：
+   - SCOPES：勾 `bot` + `applications.commands`
+   - BOT PERMISSIONS：勾 `View Channels` / `Send Messages` / `Read Message History` / `Embed Links` / `Manage Messages`（最後一個可選但強烈建議）
+   - 複製最下方產生的連結 → 在瀏覽器打開 → 選你的伺服器邀請
+
+### Step 4：設定 `.env`
+
+```bash
+cp .env.example .env
+```
+
+打開 `.env`，至少填這一行就能跑：
+
+```env
+DISCORD_TOKEN=剛剛複製的 bot token
+```
+
+其他變數（fixer 網域、AI key 等）全部可以先留空，bot 會用預設值啟動。詳情見 [.claude/rules/env.md](.claude/rules/env.md)。
+
+### Step 5：啟動
+
+```bash
+npm start
+```
+
+看到類似這行就成功了：
+
+```
+[ready] Logged in as YourBotName#1234
+```
+
+到你邀請 bot 的 Discord 伺服器丟一個 Threads / X / Instagram 連結測試，bot 會自動回覆預覽。
+
+**macOS 便利啟動**：雙擊 `start-bot.command` / `stop-bot.command`（在背景跑，關掉 terminal 也不會死）。
+
+---
+
+## @西寶 AI 回覆（可選）
+
+在任何頻道 `@西寶 你今天好嗎？` 會觸發回覆。
+
+> **「西寶」只是預設的顯示名稱與人格**。
+> - 改名字：到 Discord Developer Portal → Bot → 改 username，或直接在伺服器幫 bot 改暱稱
+> - 改人格：在 `.env` 寫 `AI_PERSONA="你是一個..."` 就會整個換掉預設個性
+> 下方所有提到「西寶」的地方，都替換成你自己取的名字即可。
+
+### 不用設定也能玩
+
+沒有任何 AI key 時，被 @ 到時還是會：
+
+- 回「`抽籤`」→ 抽今日運勢（寫死）
+- 回「`道歉`」→ 固定台詞（寫死）
+- 回其他訊息 → 隨機 4 句招呼語（寫死）
+
+### 想要真的能聊天？加一把 API key 就好
+
+支援 4 個 provider，程式內部的 fallback 鏈以「**付費優先 → 中文品質 → 備援**」排序：
+
+> **DeepSeek → Cerebras → Groq → Gemini**，任何一層失敗自動掉下一層
+
+只要**擇一**填入 `.env` 就會啟用，全部填最穩。新手建議優先申請 **Groq**（最好上手、不用綁卡），想要更好的中文品質再加 Cerebras / DeepSeek。
+
+<details>
+<summary><b>推薦：DeepSeek（超便宜付費、中文最強、不會 queue）</b></summary>
+
+1. 到 [platform.deepseek.com](https://platform.deepseek.com/)（手機或 Google 登入）
+2. 充值最少 $2 USD（單日 100 次呼叫約 $0.001 美元，基本用不完）
+3. 到 API keys 頁面建立一把 key
+4. 填入 `.env`：
+
+   ```env
+   DEEPSEEK_API_KEY=你的_key
+   DEEPSEEK_MODEL=deepseek-chat
+   ```
+
+</details>
+
+<details>
+<summary><b>最推薦新手：Groq（申請最簡單、額度大、速度快）</b></summary>
+
+1. 到 [console.groq.com/keys](https://console.groq.com/keys) Google 登入按 Create，**不用綁卡、不用充值**
+2. 免費額度：Llama 3.3 70B 每日 100k tokens、Llama 3.1 8B 每日 500k tokens
+3. 填入 `.env`：
+
+   ```env
+   GROQ_API_KEY=你的_key
+   GROQ_MODELS=llama-3.3-70b-versatile,llama-3.1-8b-instant
+   ```
+
+`GROQ_MODELS` 逗號分隔：70B 的 100k tokens/day 爆了會自動掉 8B 的 500k tokens/day。
+
+</details>
+
+<details>
+<summary><b>進階免費：Cerebras Qwen 235B（中文品質最強、1M tokens/day）</b></summary>
+
+比 Groq 稍微麻煩一點點，但中文品質明顯更好。
+
+1. 到 [cloud.cerebras.ai](https://cloud.cerebras.ai/platform/) Google 登入，Free tier 直接給 key
+2. 填入 `.env`：
+
+   ```env
+   CEREBRAS_API_KEY=你的_key
+   CEREBRAS_MODEL=qwen-3-235b-a22b-instruct-2507
+   ```
+
+</details>
+
+<details>
+<summary><b>最後防線：Gemini（有 billing 陷阱，請先讀）</b></summary>
+
+⚠️ 若 Google Cloud 專案有綁 billing（含 $300 免費試用），**Gemini free tier 會被自動停用**（`limit: 0`）。建 key 時要選「**Create API key in new project**」避免踩雷。
+
+到 [aistudio.google.com/apikey](https://aistudio.google.com/apikey) → **Create API key in new project**，然後：
+
+```env
+GEMINI_API_KEY=你的_key
+GEMINI_MODEL=gemini-2.0-flash
+```
+
+</details>
+
+**進階調整**：
+
+- `AI_PROVIDER=deepseek` → 強制只用某一層（留空 = 全鏈 fallback）
+- `AI_PERSONA="你是..."` → 覆蓋預設人格
+- 完整變數表見 [.claude/rules/env.md](.claude/rules/env.md)
+- 設計細節見 [.claude/rules/ai-providers.md](.claude/rules/ai-providers.md)
+
+---
+
+## Docker 安裝（替代方案）
+
+不想裝 Node.js？用 Docker 就好：
+
+```bash
+# 建 image
+docker build -t discord-social-preview-bot .
+
+# 前景執行（方便看 log）
+docker run --rm --env-file .env discord-social-preview-bot
+
+# 背景執行 + 自動重啟
+docker run -d \
+  --name discord-social-preview-bot \
+  --restart unless-stopped \
+  --env-file .env \
+  discord-social-preview-bot
+```
+
+---
+
+## 預覽行為詳表
 
 ### Threads
 
@@ -37,7 +236,7 @@
 | 純文字 | 自訂 embed（標題＋內文） |
 | 單張圖片 | 自訂 embed（標題＋內文＋圖片） |
 | 多張圖片 | 全圖集 embed（每張圖各一個 embed，Discord 渲染成 gallery） |
-| 影片 | 依序嘗試 fixthreads → threadsez → 資訊卡 fallback（見下方） |
+| 影片 | 依序嘗試 fixthreads → threadsez → 資訊卡 fallback |
 
 ### Instagram
 
@@ -46,7 +245,7 @@
 | 限時動態 | 無法預覽，直接回報作者名稱 |
 | 貼文 / Reels | 依序嘗試 ddinstagram → fxstagram → FixEmbed |
 
-### Other platforms
+### 其他平台
 
 | 平台 | 預覽行為 |
 |---|---|
@@ -59,262 +258,88 @@
 | 巴哈姆特 | 自訂 embed（標題＋摘要＋圖片，需公開可存取） |
 | PTT | 自訂 embed（標題＋文章內文＋第一張圖片） |
 
-## Known limitations & fallback behavior
-
-以下情形無法顯示完整影片或圖片，但 bot 會盡力提供替代資訊：
+### 無法預覽時的 fallback
 
 | 情形 | Bot 的反應 |
 |---|---|
-| Threads 影片（所有 fixer 失敗） | 資訊卡：作者名稱＋貼文文案＋「影片無法載入，請點連結觀看」 |
-| Instagram 限時動態 | 文字訊息：「這是 **@xxx** 的限動！」（無任何第三方服務支援） |
-| Instagram Reels（所有 fixer 失敗） | FixEmbed 連結（最後防線，Discord 自行嘗試 unfurl） |
+| Threads 影片（所有 fixer 失敗） | 資訊卡：作者名稱＋文案＋「影片無法載入，請點連結觀看」 |
+| Instagram 限時動態 | 文字訊息：「這是 **@xxx** 的限動！」 |
+| Instagram Reels（所有 fixer 失敗） | FixEmbed 連結（最後防線） |
 | 巴哈姆特限制板 / 登入牆 | 顯示公開部分，內文可能為空 |
 | 已刪除 / 私人 / 被限流的貼文 | 道歉訊息：「對不起對不起…預覽載入失敗了…」 |
 
-## Features
+---
 
-- Deduplicates repeated previews in the same channel
-- Suppresses the original embed if the bot has `Manage Messages`
-- Uses Playwright only for Threads metadata extraction
-- Strips common tracking parameters (`fbclid`, `gclid`, `mibextid`, `utm_*`, `igsh`, etc.) from URLs before replying — protects the poster from leaking share-tracking info, and improves dedupe
-- Bilibili short links (`b23.tv`) are expanded before fixer routing
-- `@西寶` 有人格化 AI 回覆（支援 DeepSeek / Cerebras Qwen / Groq / Gemini，chain fallback 可選）
-- AI 回覆有**短期對話記憶**（每頻道最近 8 組對話、TTL 30 分鐘）
-- Registers a `/servers` slash command so you can check how many guilds the bot is in from Discord
-- Registers a `/debug-perms` slash command so you can check the bot's channel permissions from Discord
+## 其他功能
 
-## @西寶 mention responses
+- **自動去重**：同一頻道 60 秒內的重複連結只回一次
+- **原 embed 自動收起**：bot 有 `Manage Messages` 權限時會抑制原連結的預覽
+- **tracking 參數自動去除**：`fbclid` / `gclid` / `mibextid` / `utm_*` / `igsh` 等會在發送前移除，保護分享者不洩漏 tracking 資訊
+- **Bilibili 短連結**：`b23.tv` 會先展開再轉 fixer
+- **西寶短期記憶**：每頻道記住最近 8 組對話、30 分鐘 TTL
+- **忽略標記**：訊息含 `nopreview` / `previewignore` / `fxignore` 任一字串 → bot 直接跳過
+- **Slash 指令**：`/servers`（看 bot 在幾個伺服器）、`/debug-perms`（檢查頻道權限）
 
-當訊息中 @ 到機器人時：
+---
 
-| 輸入 | 回應 |
-|---|---|
-| `抽籤` | 抽今日運勢（寫死，不走 AI） |
-| `道歉` | 固定台詞（寫死，不走 AI） |
-| 其他任何文字（含空白）| **有 AI key** → LLM 依西寶人格即時產生不重複的回覆<br>**沒有 key** → 隨機 4 句招呼 / `你…你在叫我嗎？` |
+## 疑難排解
 
-### 啟用 AI 回覆（可選，免費或超便宜付費）
+### Bot 啟動沒報錯，但不回覆訊息
 
-支援四個 provider，自動 fallback 鏈以「付費優先→品質→fallback」排列：**DeepSeek (paid) → Cerebras (Qwen 235B) → Groq (70B → 8B) → Gemini**。任何一層被 429 或失敗就掉下一層；全部失敗才走寫死回覆。
+最常見是 **Message Content Intent 忘了開**。回 Developer Portal → Bot → 確認 `MESSAGE CONTENT INTENT` 打勾，存檔後重啟 bot。
 
-**第一層：DeepSeek**（付費但超便宜，~$0.001 美元/天）
+### `/servers` 指令沒出現
 
-1. 到 [https://platform.deepseek.com/](https://platform.deepseek.com/)（手機或 Google 登入）
-2. 充值最少 $2 USD（大約可以用到地老天荒，Discord bot 一天才花幾毫錢）
-3. 到 API keys 頁面建立一把 key
-4. 模型選擇：`deepseek-chat`（V3.2 一般版）或 `deepseek-reasoner`（R1 推理版，較貴）
-5. 填入 `.env`：
+Discord 全域 slash command 需要幾分鐘 propagate。重啟 bot 後等一下即可。
 
-   ```env
-   DEEPSEEK_API_KEY=your_key_here
-   DEEPSEEK_MODEL=deepseek-chat
-   ```
+### Bot 對同一則訊息回兩次
 
-   優點：反應快、不 queue、品質頂尖、中文原生、實質無限流量。
-   缺點：中國公司、部分政治話題會偏審查、伺服器在中國延遲稍高。
+通常是開了兩個 bot instance（同個 token）。檢查有沒有舊 process 沒關：
 
-**第二層：Cerebras**（中文最強、1M tokens/day、最大模型）
+```bash
+ps aux | grep 'node.*index.js' | grep -v grep
+```
 
-1. 到 [https://cloud.cerebras.ai/platform/](https://cloud.cerebras.ai/platform/)（Free tier）申請 key
-2. 可用模型（`curl https://api.cerebras.ai/v1/models` 查看，依帳號 tier 而異）：
-   - `qwen-3-235b-a22b-instruct-2507`（Qwen 235B，中文最強，推薦）
-   - `zai-glm-4.7`（清華 GLM，中文也很好）
-   - `gpt-oss-120b`、`llama3.1-8b`
-3. 填入 `.env`：
+### Threads 預覽很慢
 
-   ```env
-   CEREBRAS_API_KEY=your_key_here
-   CEREBRAS_MODEL=qwen-3-235b-a22b-instruct-2507
-   ```
-
-**第三層：Groq**（免費額度大、速度快、適合備援）
-
-1. 到 [https://console.groq.com/keys](https://console.groq.com/keys)（Google 登入，按 Create，不用綁卡）
-2. 免費額度：Llama 3.3 70B 每日 100k tokens；Llama 3.1 8B 每日 500k tokens（更多 quota 但品質稍弱）
-3. 填入 `.env`：
-
-   ```env
-   GROQ_API_KEY=your_key_here
-   GROQ_MODELS=llama-3.3-70b-versatile,llama-3.1-8b-instant
-   ```
-
-   `GROQ_MODELS` 逗號分隔會依序 fallback：70B 的 100k 爆了 → 自動用 8B 的 500k。
-
-**第四層：Gemini**
-
-⚠️ 注意：若 Google Cloud 專案有綁 billing（含 $300 免費試用），**Gemini free tier 會被自動停用**（`limit: 0`）。建 key 時選「**Create API key in new project**」避免踩雷。
+Threads 頁面 metadata 常常延遲載入。可調整 `.env`：
 
 ```env
-GEMINI_API_KEY=your_key_here
-GEMINI_MODEL=gemini-2.0-flash
+THREADS_PROBE_TIMEOUT_MS=15000
+PLAYWRIGHT_GOTO_TIMEOUT_MS=12000
+PLAYWRIGHT_META_WAIT_TIMEOUT_MS=3000
 ```
 
-**自訂人格**：在 `.env` 寫 `AI_PERSONA="你是..."` 覆蓋預設。
+### 影片沒有 Discord 內建播放器
 
-**強制單一 provider**：如果只想用某一層，設 `AI_PROVIDER=groq|cerebras|gemini`。留空 = 全鏈 fallback。
+這是 Discord 的限制 — 自訂 embed 無法呼叫內建的 inline player，只能靠 fixer unfurl。
 
-**安全網**：AI 呼叫失敗（timeout、無額度、內容被擋、key 錯誤）都會自動退回下一層或寫死回覆，不會讓西寶沉默。啟動時會印 `[ai] chain=groq:... → cerebras:... → gemini:...` 告訴你目前的 fallback 順序。每次呼叫也會印 Groq/Cerebras 剩餘 tokens。
+### PTT 成人板預覽不出來
 
-## Requirements
+bot 已經自動帶 `over18=1` cookie，如果還是失敗代表文章已被刪除或私人化。
 
-- Node.js 20+
-- npm
-- Internet access
-- A Discord bot token
+### 巴哈姆特限制板只顯示部分內容
 
-For Threads support, this project also needs Playwright + Chromium.
+某些板鎖在登入牆或警告頁後面，bot 只能抓到未登入狀態能看到的部分。
 
-## Discord bot setup
+---
 
-1. Go to the [Discord Developer Portal](https://discord.com/developers/applications)
-2. Create an application
-3. Add a bot
-4. In **Bot**:
-   - enable `Message Content Intent`
-   - enable `Public Bot` if other people should be able to invite it
-5. In **Installation**:
-   - enable `Guild Install`
-6. Invite the bot with at least these permissions:
-   - `View Channels`
-   - `Send Messages`
-   - `Read Message History`
-   - `Embed Links`
-   - `Manage Messages` (optional, but recommended)
+## 安全提醒
 
-## Environment variables
+- **絕對不要** commit `.env` 到 git（本 repo 的 `.gitignore` 已經擋掉，別手動加）
+- **絕對不要** 把 bot token 貼到公開場所（Discord / GitHub / Slack）
+- 如果不小心外洩，立刻到 Developer Portal → Bot → **Reset Token**
 
-Copy `.env.example` to `.env`:
+---
 
-```bash
-cp .env.example .env
-```
+## 專案結構
 
-Fill in:
-
-```env
-DISCORD_TOKEN=your_bot_token_here
-FIXEMBED_BASE_URL=https://fixembed.app/embed?url=
-SUPPRESS_ORIGINAL_EMBEDS=true
-REPLY_MODE=reply
-THREADS_PROBE_TIMEOUT_MS=10000
-THREADS_METADATA_CACHE_TTL_MS=600000
-PLAYWRIGHT_GOTO_TIMEOUT_MS=8000
-PLAYWRIGHT_META_WAIT_TIMEOUT_MS=1500
-```
-
-## Local setup
-
-### macOS
-
-```bash
-npm install
-npx playwright install chromium
-npm start
-```
-
-For local macOS use, you can keep your own `start-bot.command` and `stop-bot.command` outside Git.
-
-Public startup scripts in this repo:
-
-- `scripts/start.sh`
-- `scripts/stop.sh`
-
-### Linux
-
-```bash
-npm install
-npx playwright install chromium
-sudo npx playwright install-deps chromium
-npm start
-```
-
-### Windows
-
-```powershell
-npm install
-npx playwright install chromium
-npm start
-```
-
-## Docker
-
-Build:
-
-```bash
-docker build -t discord-social-preview-bot .
-```
-
-Run:
-
-```bash
-docker run --rm \
-  --name discord-social-preview-bot \
-  --env-file .env \
-  discord-social-preview-bot
-```
-
-Background mode:
-
-```bash
-docker run -d \
-  --name discord-social-preview-bot \
-  --restart unless-stopped \
-  --env-file .env \
-  discord-social-preview-bot
-```
-
-## Project structure
-
-- [src/index.js](./src/index.js)
-- [src/threads-probe.cjs](./src/threads-probe.cjs)
-- [.env.example](./.env.example)
-- `start-bot.command` / `stop-bot.command`: local-only macOS shortcuts, intentionally gitignored
-- [scripts/start.sh](./scripts/start.sh)
-- [scripts/stop.sh](./scripts/stop.sh)
-
-
-## Troubleshooting
-
-### `/servers` command does not appear yet
-
-Global application commands such as `/servers` and `/debug-perms` can take a little while to propagate in Discord after the bot starts or restarts. If needed, restart the bot and wait a few minutes.
-
-### Bot replies twice to one message
-
-This usually means one of these conditions:
-
-- two bot instances are running with the same token
-- the bot was restarted but an older process was still alive
-- the message was processed concurrently before dedupe was recorded
-
-This project includes both recent-reply dedupe and in-flight dedupe, but you should still keep only one process running per token.
-
-### Threads preview is slow
-
-Threads pages sometimes load media metadata late. You can tune:
-
-- `THREADS_PROBE_TIMEOUT_MS`
-- `PLAYWRIGHT_GOTO_TIMEOUT_MS`
-- `PLAYWRIGHT_META_WAIT_TIMEOUT_MS`
-
-### Video is not rendered as a custom Discord player
-
-This is a Discord limitation. Custom embeds do not provide the same inline video player behavior as external unfurls.
-
-### Bahamut restricted boards may not show full content
-
-Some 巴哈姆特 boards are behind login or content-warning gates. In those cases, the bot can only show what the page exposes without logging in.
-
-### PTT adult boards require the over18 cookie
-
-The bot already sets the `over18=1` cookie in Playwright for PTT. If a page still blocks preview, the article may be unavailable or removed.
-
-## Security notes
-
-- Never commit `.env`
-- Never share your bot token
-- If a token was posted publicly, reset it immediately
+- [src/index.js](./src/index.js) — Discord client、訊息路由、embed 組裝、AI chain、西寶人格
+- [src/threads-probe.cjs](./src/threads-probe.cjs) — Playwright 子行程，抽 Threads / 巴哈 / PTT 的 OG meta
+- [.env.example](./.env.example) — 環境變數範本
+- [scripts/start.sh](./scripts/start.sh) / [scripts/stop.sh](./scripts/stop.sh) — Linux 啟動腳本
+- [.claude/rules/](./.claude/rules/) — 架構、routing、AI provider、部署細節文件
 
 ## License
 
-No license file is included yet.
+尚未加上 license 檔。


### PR DESCRIPTION
## Summary
- 新增「五分鐘快速安裝」章節，把分散的 Discord Portal / `.env` / `npm start` 步驟聚合成 5 個編號步驟
- AI provider 區塊用 `<details>` 收起，Groq 提前為新手首選（免綁卡最好上手），Cerebras 改為「進階免費」中文品質
- 標註「西寶」為可改的預設名稱與人格（Developer Portal 改名、`AI_PERSONA` 改人格）
- 疑難排解補「MESSAGE CONTENT INTENT 忘開」最常見卡點
- 4.18 更新日誌記錄本次變更

## Test plan
- [x] 目錄錨點可點擊跳轉
- [x] `<details>` 區塊可正常展開
- [x] 所有連結（platform.deepseek.com、console.groq.com、aistudio 等）可正常開啟
- [ ] GitHub 上 render 出的 markdown 排版檢查

🤖 Generated with [Claude Code](https://claude.com/claude-code)