### PR TITLE
docs(todo): 新增 AI chain circuit breaker 與多圖預設 3 張

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -30,3 +30,46 @@ Deferred work with design decisions already aligned. Pick up after blockers clea
 - **Tier 切換不該動全域常數**：`AI_MEMORY_MAX_TURNS` / `AI_MAX_REPLY_CHARS` 現在是 [src/config.js](src/config.js) 的 config 常數；要改成可以 per-guild 覆寫的查表函式。
 - **成本監控**：精細 tier 會讓 DeepSeek 月帳單明顯上升（context 拉長 + 圖片 token 貴）。實作時加一條 `[ai]` log 追蹤。
 - **Vision fallback 鏈極短**：有圖訊息只有 Gemini 一層，掛了就退回純文字 DeepSeek 或 hardcoded reply。使用者已知且接受。
+
+---
+
+## AI chain circuit breaker（失敗快取）
+
+**狀態**：想法階段，未開工。
+
+**動機**：目前 `AI_PROVIDER_CHAIN` 每次呼叫都從最高優先級開始試，某層壞掉時會持續浪費 `AI_TIMEOUT_MS`（8s）才進下一層。例如 Cerebras `queue_exceeded` 期間，每次 mention 都要多等 8 秒。
+
+### 設計方向（對齊）
+
+- **時間窗**，不是次數制。次數制在低流量頻道會鎖在較差的 provider 上好幾小時。
+- **per-provider 狀態 Map**：`{ nextRetryAt, consecutiveFails }`，in-memory（跟 `aiConversationHistory` 一致，重啟清掉）。
+- **失敗分類冷卻**：
+  - `401/403`（key 失效）→ 冷卻久一點，甚至 runtime 關閉該層
+  - `queue_exceeded` / `timeout` / 5xx → 冷卻 30–60 秒
+  - 空 candidate / 安全阻擋 → 不冷卻（這是內容問題不是 provider 問題）
+- **Observability**：`[ai] skipping <provider>:<model> (cooldown Xs remaining, reason=<...>)`
+
+### 待決定
+
+- 連續失敗次數是否拉長冷卻（指數退避 vs 固定 60s）
+- 是否要一個 `/ai-status` 斜線指令查目前各層狀態（debug 用）
+
+---
+
+## 多圖預覽預設只顯示 3 張
+
+**狀態**：想法階段，未開工。
+
+**動機**：Threads / 其他平台多圖貼文現在全部攤平在 embed 裡，訊息很長佔頻道空間。
+
+### 設計方向（待對齊）
+
+- 預設只顯示前 3 張圖 + 「還有 N 張」提示
+- 提供按鈕（`Open on X` 風格）點開看全部，或直接連到原貼文
+- Discord 單則 message 最多 10 張 embed image 的硬限制還是存在，這個是 UX 限制不是技術限制
+
+### 待決定
+
+- 「點開看全部」是：（a）編輯原訊息展開全部 embeds、（b）跳轉到原貼文、（c）發 ephemeral follow-up 給點擊者？
+- 影響範圍：Threads 多圖 branch、其他平台目前是交給 fixer 處理不會受影響——確認一下 Bahamut / PTT probe 有沒有自組多圖 embed 的路徑
+- 3 張這個預設值是否要可調（env var `MULTI_IMAGE_PREVIEW_COUNT`）


### PR DESCRIPTION
## Summary
- todo.md 加入兩個 deferred 想法：AI chain circuit breaker（時間窗制失敗冷卻）與多圖預設只顯示 3 張
- 純文件改動，沒有動 code
- 兩個項目都還在設計階段，待之後對齊細節後再開實作分支

## Test plan
- [x] 只改 todo.md，不需要跑測試

🤖 Generated with [Claude Code](https://claude.com/claude-code)