### PR TITLE
docs(rules): refactor 後 rule 檔連結指向正確模組

### DIFF
--- a/.claude/rules/ai-providers.md
+++ b/.claude/rules/ai-providers.md
@@ -2,7 +2,9 @@
 
 ## Entry point
 
-`generateAIReply(message, userText)` in [src/index.js](../../src/index.js) is the single entry point for `@西寶` AI replies. It builds a `userTurn` string via `buildUserTurn()`, then iterates over `AI_PROVIDER_CHAIN` (built once at startup by `buildAIProviderChain()`).
+`generateAIReply(message, userText)` in [src/ai/chain.js](../../src/ai/chain.js) is the single entry point for `@西寶` AI replies. It builds a `userTurn` string via `buildUserTurn()` (from [src/ai/persona.js](../../src/ai/persona.js)), then iterates over `AI_PROVIDER_CHAIN` (built once at module load by `buildAIProviderChain()`).
+
+Provider implementations live in [src/ai/providers.js](../../src/ai/providers.js); per-channel memory in [src/ai/memory.js](../../src/ai/memory.js).
 
 **First non-null reply wins.** On null/error, move to the next layer. Chain exhausted → returns `null` → mention handler falls back to hardcoded replies.
 

--- a/.claude/rules/persona.md
+++ b/.claude/rules/persona.md
@@ -2,7 +2,7 @@
 
 ## Identity
 
-Shy, flustered, self-deprecating. Uses `///` and ellipses `…`. Full persona defined in `DEFAULT_AI_PERSONA` (`src/index.js`); overridable via `AI_PERSONA` env var.
+Shy, flustered, self-deprecating. Uses `///` and ellipses `…`. Full persona defined in `DEFAULT_AI_PERSONA` ([src/config.js](../../src/config.js)); overridable via `AI_PERSONA` env var. Consumed by [src/ai/persona.js](../../src/ai/persona.js) which builds provider-specific message formats.
 
 Reference origin & evolution: see user memory `project_xibao_persona.md` (A–G taxonomy, v1~v6 history).
 

--- a/.claude/rules/routing.md
+++ b/.claude/rules/routing.md
@@ -1,5 +1,7 @@
 # Platform Routing (`buildPreviewPayloads`)
 
+Top-level dispatcher: [src/preview.js](../../src/preview.js). Per-platform builders under [src/platforms/](../../src/platforms/).
+
 ## Threads
 
 | Condition | Output |
@@ -10,7 +12,7 @@
 | `summary_large_image` + single image | Custom embed with image |
 | Fallback / probe error | Fixer link (`FIXER_THREADS`) |
 
-**Order is load-bearing.** See code in [src/index.js](../../src/index.js) around the Threads routing block — the `if` ladder order determines which branch a mixed (image+video) post falls into.
+**Order is load-bearing.** See [src/platforms/threads.js](../../src/platforms/threads.js) — the `if` ladder order determines which branch a mixed (image+video) post falls into. Hard-asserted by [scripts/routing-smoke.js](../../scripts/routing-smoke.js) (MIXED case: multi-image AND video → carousel wins).
 
 ## Instagram
 


### PR DESCRIPTION
## Summary

PR #15 把 \`src/index.js\` 拆成 17 個 CommonJS 模組後，\`.claude/rules/*.md\` 裡三條功能描述還指著舊的 monolith \`src/index.js\`。對未來讀文件的人（包括 Claude agent）會誤導。

## 改動

| 檔案 | 之前 | 之後 |
|---|---|---|
| \`.claude/rules/routing.md:13\` | Threads routing 在 \`src/index.js\` | \`src/platforms/threads.js\` + 加上 \`scripts/routing-smoke.js\` hard-assertion 連結 |
| \`.claude/rules/ai-providers.md:5\` | \`generateAIReply\` 在 \`src/index.js\` | \`src/ai/chain.js\` + 標示 persona / providers / memory 位置 |
| \`.claude/rules/persona.md:5\` | \`DEFAULT_AI_PERSONA\` 在 \`src/index.js\` | \`src/config.js\` + 補 \`src/ai/persona.js\` 負責訊息格式 |

\`.claude/rules/deploy.md\` 裡的 \`src/index.js\` 是啟停指令字串（\`pkill -f 'src/index.js'\`、\`node src/index.js\`），保留。

## Test plan
- [x] grep 確認沒有其他遺漏的 \`src/index.js\` 功能引用
- [x] 新 link 路徑在檔案系統上確實存在（\`src/platforms/threads.js\` / \`src/ai/chain.js\` / \`src/ai/persona.js\` / \`src/ai/providers.js\` / \`src/ai/memory.js\` / \`src/config.js\`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)