### PR TITLE
fix(mention): 抽籤/運勢 包含即觸發 + 小吉中吉語氣調整

### DIFF
--- a/src/mention.js
+++ b/src/mention.js
@@ -13,8 +13,8 @@ const FORTUNE_RESULTS = [
 
 const FORTUNE_COMMENTS = {
   大吉: ["今天會是很好的一天喔！", "哇…真的嗎…好厲害！", "運氣超好的…羨慕///"],
-  中吉: ["還不錯啦…差不多啦。", "算是好的吧…應該啦…", "嗯…不差不差。"],
-  小吉: ["還好啦…小小的幸運～", "有一點點好運喔。", "差強人意…吧？"],
+  中吉: ["嗯…是好運喔！", "今天應該會順順的～", "有點小期待…的一天呢。"],
+  小吉: ["還好啦…小小的幸運～", "有一點點好運喔。", "有點小確幸喔…"],
   末吉: ["唔…勉強算吉吧…", "就…就還行吧？", "平平淡淡的一天。"],
   吉: ["普通普通…", "就是正常啦～", "嗯，還行喔！"],
   凶: ["今天要小心一點喔…", "有點不好耶…好擔心…", "…要注意安全喔。"],
@@ -49,7 +49,7 @@ async function handleMention(message, client) {
     .trim();
   const textLower = text.toLowerCase();
 
-  if (textLower === "抽籤") {
+  if (textLower.includes("抽籤") || textLower.includes("運勢")) {
     const result = drawFortune();
     const comment = pickRandom(FORTUNE_COMMENTS[result]);
     await message.reply({


### PR DESCRIPTION
## Summary
- `@西寶` 後面只要包含 `抽籤` 或 `運勢` 就強制走寫死的抽籤路徑（機率 + 固定評語），避免「抽籤 麻煩你囉」這種句子落空跑 AI 亂編劇情
- 小吉第三句 `差強人意…吧？` 語意容易被誤解為貶義 → 改為 `有點小確幸喔…`，比末吉正面一點
- 中吉三句原本讀起來像「還可以」，跟小吉區隔不大 → 改為更明確的好運語氣，但沒到大吉「羨慕///」的誇張程度

語氣層級：小吉（小小幸運）< 中吉（明確好運）< 大吉（超好運）

## Test plan
- [ ] `@西寶 抽籤` → 抽籤
- [ ] `@西寶 抽籤 麻煩你囉` → 抽籤（之前會落空跑 AI）
- [ ] `@西寶 幫我抽運勢` → 抽籤
- [ ] `@西寶 道歉` → 仍走道歉路徑（未動）
- [ ] `@西寶 你好` → 仍走 AI 路徑
- [ ] 多抽幾次確認小吉／中吉出現新評語

🤖 Generated with [Claude Code](https://claude.com/claude-code)