### PR TITLE
docs(deploy): add tmux redeploy section as nohup alternative

### DIFF
--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -14,7 +14,7 @@ macOS convenience scripts: `start-bot.command` / `stop-bot.command`.
 
 ## Production deployment (SSH host)
 
-Bot runs 24/7 on a Linux lab machine via `nohup`. Path: `~/side_projects/discord-social-preview-bot/`.
+Bot runs 24/7 on a Linux lab machine — either via `nohup` (scripted redeploys) or inside a long-lived `tmux` session (preferred for hands-on ops). Path: `~/side_projects/discord-social-preview-bot/`.
 
 ### Daily ops
 
@@ -65,6 +65,24 @@ No `[commands]` line appears when all registered commands already match — this
 grep -i 'error\|unhandled\|ECONN\|ENOTFOUND' bot.log
 grep 'chain exhausted' bot.log   # AI chain drained for every mention
 ```
+
+### Manual redeploy via tmux (preferred for hands-on ops)
+
+Same effect as nohup, but lets you re-attach to watch the log live. Session name: `dcbot`.
+
+```bash
+ssh <host>
+tmux attach -t dcbot || tmux new -s dcbot
+cd ~/side_projects/discord-social-preview-bot
+git pull
+# 若 pane 裡已在跑 node：Ctrl+C 停掉，再執行
+node src/index.js
+# Detach：Ctrl+b 再按 d — bot 繼續跑
+```
+
+To stop entirely: attach, `Ctrl+C`, then `exit` to kill the pane.
+
+Verify the same `Logged in as ...` / `目前已加入 ... 個伺服器` / `[ai] chain=...` lines as the nohup flow above — they print to the tmux pane instead of `bot.log`.
 
 ### Shadow-deploy a branch (test before merge)
 


### PR DESCRIPTION
## Summary
- 在 `.claude/rules/deploy.md` 新增「Manual redeploy via tmux」段落，說明用 `tmux attach -t dcbot` 即時看 log 的部署流程
- 把 lead 句改成「via nohup 或 tmux session」，反映兩條合法路徑

## Why
手動部署時偏好 tmux（可以即時看 console 而不是 tail bot.log）。今天部署遇到 nohup 退出 125、改用 tmux 順利重啟，把這條路徑寫進 docs 給未來自己/AI 參考。nohup 流程保留作為腳本化選項。

## Test plan
- [x] docs only — 沒有 code 改動
- [x] 本地 `git diff` 檢查格式正確
- [ ] PR review

🤖 Generated with [Claude Code](https://claude.com/claude-code)