### PR TITLE
fix(commands): /debug-perms null-guild guard + interaction try/catch

### DIFF
--- a/scripts/smoke.js
+++ b/scripts/smoke.js
@@ -51,6 +51,9 @@ const {
   getTierConfig,
 } = require("../src/tier-config");
 
+const { buildPermissionDebugMessage } = require("../src/commands");
+const { getMissingChannelPermissions } = require("../src/discord-io");
+
 let pass = 0;
 let fail = 0;
 function it(name, fn) {
@@ -634,6 +637,33 @@ it("brief has no group context, standard/detailed do", () => {
   assert.equal(TIERS.brief.groupContextCount, 0);
   assert.ok(TIERS.standard.groupContextCount > 0);
   assert.ok(TIERS.detailed.groupContextCount > 0);
+});
+
+console.log("");
+console.log("debug-perms null-guild guard");
+it("buildPermissionDebugMessage returns DM message when not in guild", () => {
+  const msg = buildPermissionDebugMessage({ inGuild: () => false });
+  assert.match(msg, /只能在伺服器/);
+});
+it("buildPermissionDebugMessage handles inGuild()=true with guild=null without throwing", () => {
+  // Reproduces the prod crash: Discord delivered an interaction whose
+  // guildId was set (so inGuild() returns true) but the bot's cache had
+  // no entry for that guild, so .guild was null. Reading .guild.members
+  // used to throw and bring the whole process down.
+  const msg = buildPermissionDebugMessage({
+    inGuild: () => true,
+    guild: null,
+    guildId: "999",
+    channelId: "888",
+  });
+  assert.match(msg, /只能在伺服器/);
+});
+it("getMissingChannelPermissions returns sentinel when guild is null", () => {
+  const result = getMissingChannelPermissions({
+    inGuild: () => true,
+    guild: null,
+  });
+  assert.deepEqual(result, ["GuildUnavailable"]);
 });
 
 console.log("");

--- a/src/commands.js
+++ b/src/commands.js
@@ -81,7 +81,7 @@ async function ensureApplicationCommands(client) {
 }
 
 function buildPermissionDebugMessage(interaction) {
-  if (!interaction.inGuild()) {
+  if (!interaction.inGuild() || !interaction.guild) {
     return "這個指令只能在伺服器頻道內使用。";
   }
 

--- a/src/discord-io.js
+++ b/src/discord-io.js
@@ -62,6 +62,10 @@ function describeMessageLocation(message) {
 
 function getMissingChannelPermissions(message) {
   if (!message.inGuild()) return [];
+  // inGuild() can be true while .guild is null when the bot isn't in
+  // the guild's cache (e.g. kicked/restored mid-session). Guard so the
+  // caller doesn't blow up reading .members on null.
+  if (!message.guild) return ["GuildUnavailable"];
   const me = message.guild.members.me;
   if (!me) return ["BotMemberUnavailable"];
   const permissions = message.channel.permissionsFor(me);

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 require("dotenv").config();
 
-const { Client, GatewayIntentBits } = require("discord.js");
+const { Client, GatewayIntentBits, MessageFlags } = require("discord.js");
 
 const { DISCORD_TOKEN, AI_TIMEOUT_MS } = require("./config");
 const { shouldIgnoreMessage, extractSupportedUrls } = require("./url-routing");
@@ -68,7 +68,31 @@ client.on("guildDelete", (guild) => {
 });
 
 client.on("interactionCreate", async (interaction) => {
-  await handleInteraction(interaction, client);
+  // Any throw here propagates to the Client 'error' event and crashes
+  // the whole process (no auto-restart). Swallow + log so a bug in one
+  // handler can't take 西寶 offline.
+  try {
+    await handleInteraction(interaction, client);
+  } catch (err) {
+    console.error(
+      `[commands] interaction handler error name=${interaction.commandName} guildId=${interaction.guildId ?? "none"}: ${err?.stack || err}`,
+    );
+    try {
+      const replyPayload = {
+        content: "指令執行失敗了…抱歉 🙏",
+        flags: MessageFlags.Ephemeral,
+      };
+      if (interaction.deferred || interaction.replied) {
+        await interaction.followUp(replyPayload);
+      } else if (interaction.isRepliable()) {
+        await interaction.reply(replyPayload);
+      }
+    } catch (replyErr) {
+      console.warn(
+        `[commands] failed to send error reply: ${replyErr?.message || replyErr}`,
+      );
+    }
+  }
 });
 
 client.on("messageCreate", async (message) => {


### PR DESCRIPTION
## Summary

- Production crashed earlier today (see logs) when someone triggered `/debug-perms` in a context where Discord delivered `interaction.inGuild()===true` but `interaction.guild===null` — bot cache had no entry for that guild. Reading `.guild.members.me` threw, the error escaped to the Client `'error'` emitter, and the whole process died (no auto-restart yet).
- Three layers of defence:
  - **`getMissingChannelPermissions`** now returns `["GuildUnavailable"]` when `.guild` is null instead of crashing.
  - **`buildPermissionDebugMessage`** treats null `.guild` the same as not-in-guild (returns the standard "只能在伺服器頻道內使用" reply).
  - **`interactionCreate` handler** in `src/index.js` wraps `handleInteraction` in try/catch and posts an ephemeral error message — so any future handler bug can't take 西寶 offline.
- Three new pure-smoke cases assert the null-guild path doesn't throw.

## Test plan

- [x] `npm run test:pure` — 70 passed (3 new debug-perms guard cases included)
- [x] `npm run test:routing` — 18 passed
- [x] `npm run test:circuit` — 26 passed
- [ ] After merge: SSH `ntnumaplab2`, `git pull`, restart, verify `bot.log` shows `Logged in as 西寶#3418` + `[ai] chain=...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)