### PR TITLE
chore(ops): cron watchdog to auto-restart bot on crash

### DIFF
--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -92,7 +92,14 @@ nohup node src/index.js > bot.log 2>&1 &
 
 `.env` lives on the deploy host, not in git. To rotate keys: scp a fresh `.env` from a trusted machine, or edit with `nano` on the host.
 
+## Auto-restart watchdog
+
+A cron watchdog restarts the bot within ~1 min if its process dies (crash, ENOSPC, reboot). Script: [scripts/bot-watchdog.sh](../../scripts/bot-watchdog.sh), installed as `* * * * *` in the user crontab. Restart events log to `/tmp/bot_watchdog.log`; bot stdout still appends to `bot.log`.
+
+- The watchdog matches the process with `pgrep -f '[n]ode src/index.js'` — the `[n]` bracket trick stops the pattern from matching the watchdog's own shell. (Plain `pkill -f 'src/index.js'` from an interactive shell self-matches and can kill the shell — prefer `pgrep -f 'node src/index.js'` → `kill <pid>` for manual ops.)
+- **To stop the bot for maintenance, comment out the cron line first** — otherwise the watchdog relaunches it within a minute.
+
 ## Future hardening (not yet done)
 
-- systemd service for auto-restart on crash/reboot
+- systemd service for auto-restart on crash/reboot (cron watchdog above covers the common case)
 - log rotation for `bot.log`

--- a/scripts/bot-watchdog.sh
+++ b/scripts/bot-watchdog.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Cron-driven watchdog for the Discord social-preview bot (西寶).
+# Runs as user kojiek every minute. If the node process is gone, restart it.
+#
+# Install:
+#   chmod +x /home/kojiek/side_projects/discord-social-preview-bot/scripts/bot-watchdog.sh
+#   ( crontab -l 2>/dev/null; echo '* * * * * /home/kojiek/side_projects/discord-social-preview-bot/scripts/bot-watchdog.sh' ) | crontab -
+#
+# The [n]ode bracket trick keeps the pattern from matching the watchdog's
+# own command line via the shell that ran pgrep.
+
+set -u
+
+REPO=/home/kojiek/side_projects/discord-social-preview-bot
+WD_LOG=/tmp/bot_watchdog.log
+
+cd "$REPO" || exit 1
+
+if pgrep -f '[n]ode src/index.js' > /dev/null; then
+  exit 0
+fi
+
+nohup setsid node src/index.js >> "$REPO/bot.log" 2>&1 < /dev/null &
+disown
+
+ts=$(date '+%Y-%m-%dT%H:%M:%S%z')
+pid=$(pgrep -f '[n]ode src/index.js' | head -1)
+echo "$ts watchdog: bot not running, restarted (pid=${pid:-unknown})" >> "$WD_LOG"


### PR DESCRIPTION
## Summary
- Adds `scripts/bot-watchdog.sh` — a cron-driven watchdog (every minute) that restarts the bot if its node process is gone. Modelled on the existing `gpu_tracker/deploy/collector-watchdog.sh`, including the `[n]ode` bracket trick so `pgrep` doesn't match the watchdog's own shell.
- Documents the watchdog in `deploy.md`, plus a note that manual ops should use `pgrep -f 'node src/index.js'` → `kill` (the old `pkill -f 'src/index.js'` self-matches an interactive shell).

## Motivation
The bot was down 6 days after a May 10 ENOSPC crash because nothing supervises it — manual `nohup` only. The watchdog brings recovery time down to ~1 min for crashes, ENOSPC, and reboots.

## Already done on host
- Script installed + `chmod +x`, cron line `* * * * * .../scripts/bot-watchdog.sh` added to the user crontab.
- Verified: no-op when bot is up; restarts within seconds when killed (logged to `/tmp/bot_watchdog.log`).

## Test plan
- [x] `npm test` — all three smoke layers pass (26 passed, 0 failed)
- [x] Watchdog no-op while bot running (`exit=0`)
- [x] Watchdog restarts bot after kill; startup banner confirmed in `bot.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)