### PR TITLE
chore: ignore bot.log.* backup/crash logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ npm-debug.log*
 start-bot.command
 stop-bot.command
 bot.log
+bot.log.*
 *.log
 data/
 


### PR DESCRIPTION
## Summary
- Adds `bot.log.*` to `.gitignore` so rotated/crash-dump logs (e.g. `bot.log.2026-05-10.crashed`, `bot.log.<ts>.bak`) stop showing as untracked. The existing `bot.log` / `*.log` rules missed the `.crashed` / `.bak` suffixes.

## Test plan
- [x] `git check-ignore` confirms both existing backup logs are now ignored
- No code change; smoke tests unaffected