### PR TITLE
feat: 西寶 web search via DeepSeek tool-calling (Tavily)

### DIFF
--- a/.claude/rules/ai-providers.md
+++ b/.claude/rules/ai-providers.md
@@ -30,6 +30,16 @@ If a free guild has exhausted `AI_FREE_DAILY_LIMIT`, the DeepSeek entry is skipp
 - Each provider call returns a result object: `{ ok: true, text }` on success, `{ ok: false, kind, ... }` on failure (`kind` ∈ `auth` / `rate_limit` / `timeout` / `network` / `server` / `queue_exceeded` / `empty` / `unknown`). Helpers `ok(text)` / `fail(kind, extra)` in [providers.js](../../src/ai/providers.js).
 - Any per-layer failure triggers the next layer — **bot never goes silent**.
 
+## Web search (tool-calling)
+
+DeepSeek's **API** has no native web search (only the consumer app does), so `@西寶` searches via OpenAI-style function calling: DeepSeek decides it needs fresh info → emits a `web_search` tool call → [web-search.js](../../src/ai/web-search.js) runs the query against **Tavily** → result is fed back as a `tool` message → DeepSeek answers using it. Implemented in `callDeepSeek`'s tool loop ([providers.js](../../src/ai/providers.js)), capped at `MAX_TOOL_ROUNDS` (2) before a text answer is forced.
+
+- **DeepSeek-only.** `tools` are wired only on the DeepSeek entries in `buildGuildChain`; Groq/Gemini fallbacks answer without search.
+- **Off by default.** No `TAVILY_API_KEY` → `isWebSearchEnabled()` false → no `tools` sent → plain completion, byte-identical to before.
+- **Double daily cap.** `runWebSearch` checks `web:global` then `web:<guildId>` via the shared rate-limiter (separate key namespace from the DeepSeek free-tier counter) so a free Tavily key (~1000/month) can't be drained.
+- **Failures are soft.** Quota-exhausted / HTTP error / timeout return a short Chinese note as the tool result instead of throwing — 西寶 just answers without the data.
+- Log prefix `[web-search]`; `callDeepSeek` logs `ran N tool call(s) round=<r>`.
+
 ## Circuit breaker
 
 [src/ai/circuit.js](../../src/ai/circuit.js) keeps a per-provider-label cooldown so the chain doesn't waste `AI_TIMEOUT_MS` (8 s) re-trying a known-broken provider on every mention.

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -23,6 +23,7 @@ CommonJS modules under `src/`. Entry point is [src/index.js](../../src/index.js)
 - [memory.js](../../src/ai/memory.js) — per-channel conversation history + sweep timer.
 - [providers.js](../../src/ai/providers.js) — `callDeepSeek` / `callGroq` / `callGemini` + `withAbortTimeout` + `parseRetryAfterMs` + `ok` / `fail` result helpers.
 - [circuit.js](../../src/ai/circuit.js) — provider circuit breaker (`isProviderAvailable` / `recordProviderFailure` / cooldown lookup). Stops the chain from re-trying a known-broken provider every call.
+- [web-search.js](../../src/ai/web-search.js) — Tavily web search exposed to DeepSeek via tool-calling (`WEB_SEARCH_TOOL` + `runWebSearch` + `makeToolCallHandler`), double daily quota cap. See [ai-providers.md](ai-providers.md).
 - [group-context.js](../../src/ai/group-context.js) — fetches recent non-bot messages and formats them into a `## 最近群組對話` user-role context turn for 標準 / 精細 plans.
 - [chain.js](../../src/ai/chain.js) — `buildAIProviderChain` + `runProviderChain` + `generateAIReply`. Single entry point for `@西寶` AI replies.
 
@@ -49,6 +50,7 @@ src/
 │   ├── memory.js         # Per-channel conversation history + sweep timer
 │   ├── providers.js      # callDeepSeek/callGroq/callGemini + ok/fail/parseRetryAfterMs
 │   ├── circuit.js        # Per-provider cooldown state (isProviderAvailable / recordProviderFailure)
+│   ├── web-search.js     # Tavily search via DeepSeek tool-calling + daily quota caps
 │   ├── group-context.js  # Recent non-bot messages → user-role context turn (standard/detailed)
 │   └── chain.js          # buildAIProviderChain + runProviderChain + generateAIReply
 ├── mention.js            # @西寶 dispatcher (抽籤 / 道歉 / AI / hardcoded fallback)
@@ -62,7 +64,7 @@ src/
 
 All scoped — grep one to isolate a subsystem:
 
-`[preview]` · `[threads-meta]` · `[ai]` · `[group-context]` · `[probe]` · `[permissions]` · `[mention]` · `[commands]`
+`[preview]` · `[threads-meta]` · `[ai]` · `[group-context]` · `[web-search]` · `[probe]` · `[permissions]` · `[mention]` · `[commands]`
 
 ## Smoke tests
 

--- a/.claude/rules/env.md
+++ b/.claude/rules/env.md
@@ -43,5 +43,10 @@
 | `AI_MEMORY_TTL_MS` | `1800000` | Inactivity before channel memory is evicted (30 min) |
 | `AI_LONG_TERM_MEMORY_ENABLED` | `true` | Enables user/guild long-term observation extraction and profile prompt blocks |
 | `EMOJI_TRUSTED_GUILD_IDS` | — | Comma-separated guild IDs whose custom emoji may be shared when the current guild is also trusted |
+| `TAVILY_API_KEY` | — | Optional. Enables `@西寶` web search via DeepSeek tool-calling. Empty = search disabled (no-op). Sign up at tavily.com (free ~1000/month). See [ai-providers.md](ai-providers.md) |
+| `WEB_SEARCH_MAX_RESULTS` | `5` | Results fetched + shown per search |
+| `WEB_SEARCH_DAILY_LIMIT_GUILD` | `15` | Per-guild daily search cap |
+| `WEB_SEARCH_DAILY_LIMIT_GLOBAL` | `30` | Global daily search cap (≈900/month, under Tavily free tier) |
+| `WEB_SEARCH_TIMEOUT_MS` | `8000` | Tavily request timeout |
 
 **Reply length, memory depth, and DeepSeek model selection are now per-guild AI plan settings** (see [persona.md](persona.md) `/ai-tier` section), not env vars. The legacy `AI_MAX_REPLY_CHARS` / `AI_MEMORY_MAX_TURNS` env vars are no longer read.

--- a/.claude/rules/scripts.md
+++ b/.claude/rules/scripts.md
@@ -66,8 +66,9 @@ Covered:
 - `getCooldownMs` per `kind` (auth 10 min, rate_limit honours retryAfterMs, timeout/network/server 60 s, queue_exceeded 30 s, **empty 0 ms**, unknown 30 s).
 - `isProviderAvailable` / `recordProviderSuccess` / `recordProviderFailure` state transitions, `failCount` increments, `cooldownRemainingMs`.
 - `runProviderChain` — first ok wins; cooling-down provider is skipped; failure cascades to next provider; chain-all-fail returns `null`; chain-all-cooling returns `null` *and calls nothing*; `empty` failure does NOT cool the provider (still callable next call).
+- **Web search** — `WEB_SEARCH_TOOL` shape; `runWebSearch` empty-query + missing-key paths; `makeToolCallHandler` dispatch (web_search vs unknown); `callDeepSeek` tool loop (search round → tool result fed back → final answer) and plain-completion-sends-no-tools. (`formatTavilyResults` pure rendering is covered in `scripts/smoke.js`.)
 
-**When to run**: any change to `chain.js`, `circuit.js`, `providers.js` failure classification, or the `ok` / `fail` shape.
+**When to run**: any change to `chain.js`, `circuit.js`, `providers.js` failure classification / tool loop, `web-search.js`, or the `ok` / `fail` shape.
 
 ## What none of these cover
 

--- a/scripts/smoke-ai-circuit.js
+++ b/scripts/smoke-ai-circuit.js
@@ -8,8 +8,10 @@ const assert = require("node:assert/strict");
 
 process.env.DISCORD_TOKEN = process.env.DISCORD_TOKEN || "smoke-dummy";
 process.env.DEEPSEEK_API_KEY = process.env.DEEPSEEK_API_KEY || "sk-smoke-dummy";
+// web-search off by default in tests; individual tests stub global.fetch.
+delete process.env.TAVILY_API_KEY;
 
-const { parseRetryAfterMs, ok, fail } = require("../src/ai/providers");
+const { parseRetryAfterMs, ok, fail, callDeepSeek } = require("../src/ai/providers");
 const {
   getCooldownMs,
   isProviderAvailable,
@@ -37,6 +39,11 @@ const {
   getUsage,
   resetForTests: resetRateLimiter,
 } = require("../src/ai/rate-limiter");
+const {
+  WEB_SEARCH_TOOL,
+  runWebSearch,
+  makeToolCallHandler,
+} = require("../src/ai/web-search");
 
 let pass = 0;
 let fails = 0;
@@ -372,6 +379,98 @@ async function main() {
     const dsEntry = chain.find((e) => e.label.startsWith("deepseek:"));
     assert.ok(dsEntry);
     assert.ok(dsEntry.label.includes("flash"), `expected flash model, got ${dsEntry.label}`);
+  });
+
+  console.log("web-search");
+  it("WEB_SEARCH_TOOL has the expected OpenAI tool shape", () => {
+    assert.equal(WEB_SEARCH_TOOL.type, "function");
+    assert.equal(WEB_SEARCH_TOOL.function.name, "web_search");
+    assert.deepEqual(WEB_SEARCH_TOOL.function.parameters.required, ["query"]);
+  });
+  await itAsync("runWebSearch rejects an empty query", async () => {
+    assert.equal(await runWebSearch("   "), "（沒有提供搜尋關鍵字）");
+  });
+  await itAsync("runWebSearch reports missing key (disabled in tests)", async () => {
+    assert.equal(await runWebSearch("天氣"), "（沒設定搜尋功能，沒辦法上網查）");
+  });
+  await itAsync("makeToolCallHandler routes web_search and rejects unknown tools", async () => {
+    const handler = makeToolCallHandler("g1");
+    assert.match(await handler("web_search", { query: "x" }), /沒設定搜尋功能/);
+    assert.match(await handler("nope", {}), /未知的工具/);
+  });
+
+  console.log("callDeepSeek tool-calling");
+  await itAsync("runs a tool call, feeds the result back, returns the answer", async () => {
+    const responses = [
+      {
+        choices: [
+          {
+            message: {
+              role: "assistant",
+              content: null,
+              tool_calls: [
+                { id: "tc1", function: { name: "web_search", arguments: '{"query":"颱風"}' } },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+      },
+      { choices: [{ message: { content: "查到了，明天放假喔" }, finish_reason: "stop" }] },
+    ];
+    const sent = [];
+    let toolSeen = null;
+    let i = 0;
+    const origFetch = global.fetch;
+    global.fetch = async (url, opts) => {
+      sent.push(JSON.parse(opts.body));
+      const payload = responses[i++];
+      return { ok: true, headers: new Map(), json: async () => payload, text: async () => "" };
+    };
+    try {
+      const res = await callDeepSeek(
+        [{ role: "user", content: "明天會放颱風假嗎" }],
+        "persona",
+        100,
+        {
+          tools: [WEB_SEARCH_TOOL],
+          onToolCall: async (name, args) => {
+            toolSeen = { name, args };
+            return "氣象局：明天停班停課";
+          },
+        },
+      );
+      assert.equal(res.ok, true);
+      assert.equal(res.text, "查到了，明天放假喔");
+      assert.deepEqual(toolSeen, { name: "web_search", args: { query: "颱風" } });
+      assert.ok(sent[0].tools, "round 0 offered tools");
+      assert.ok(
+        sent[1].messages.some((m) => m.role === "tool" && m.content === "氣象局：明天停班停課"),
+        "tool result fed back on round 1",
+      );
+    } finally {
+      global.fetch = origFetch;
+    }
+  });
+  await itAsync("plain completion sends no tools and returns text", async () => {
+    let sentBody = null;
+    const origFetch = global.fetch;
+    global.fetch = async (url, opts) => {
+      sentBody = JSON.parse(opts.body);
+      return {
+        ok: true,
+        headers: new Map(),
+        json: async () => ({ choices: [{ message: { content: "嗨嗨" } }] }),
+        text: async () => "",
+      };
+    };
+    try {
+      const res = await callDeepSeek([{ role: "user", content: "hi" }], "p", 50);
+      assert.equal(res.text, "嗨嗨");
+      assert.equal(sentBody.tools, undefined);
+    } finally {
+      global.fetch = origFetch;
+    }
   });
 
   // cleanup

--- a/scripts/smoke.js
+++ b/scripts/smoke.js
@@ -10,6 +10,9 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 process.env.DISCORD_TOKEN = process.env.DISCORD_TOKEN || "smoke-dummy";
+// Keep web-search disabled in tests regardless of the shell env (config caches
+// this at require time, so it must be cleared before the first require below).
+delete process.env.TAVILY_API_KEY;
 
 const {
   normalizeUrl,
@@ -59,6 +62,9 @@ const {
   resolveCustomEmojis,
   buildEmojiPromptBlock,
 } = require("../src/ai/emoji-resolver");
+
+const { formatTavilyResults, isWebSearchEnabled } =
+  require("../src/ai/web-search");
 
 const { buildPermissionDebugMessage } = require("../src/commands");
 const { getMissingChannelPermissions } = require("../src/discord-io");
@@ -1692,6 +1698,40 @@ it("buildBedtimeStoryPrompt includes mode, ingredients, and anti-repetition", ()
   assert.match(built.prompt, /dream-chatroom/);
   assert.ok(built.modeKey);
   assert.equal(built.dateKey, "2026-05-29");
+});
+
+console.log("web-search (pure)");
+it("formatTavilyResults renders answer + numbered results", () => {
+  const out = formatTavilyResults(
+    {
+      answer: "明天晴天",
+      results: [
+        { title: "氣象", content: "晴   時   多雲", url: "http://w" },
+        { title: "新聞", content: "x", url: "" },
+      ],
+    },
+    "天氣",
+  );
+  assert.match(out, /摘要：明天晴天/);
+  assert.match(out, /\[1\] 氣象/);
+  assert.match(out, /晴 時 多雲/); // whitespace collapsed
+  assert.match(out, /\(http:\/\/w\)/);
+  assert.match(out, /\[2\] 新聞/);
+});
+it("formatTavilyResults handles no results", () => {
+  assert.equal(formatTavilyResults({ results: [] }, "X"), "（找不到「X」的相關結果）");
+  assert.equal(formatTavilyResults({}, "Y"), "（找不到「Y」的相關結果）");
+});
+it("formatTavilyResults caps long content at 400 chars", () => {
+  const out = formatTavilyResults(
+    { results: [{ title: "T", content: "a".repeat(600), url: "" }] },
+    "q",
+  );
+  const contentLine = out.split("\n").find((l) => l.startsWith("a"));
+  assert.ok(contentLine.length <= 400, `content too long: ${contentLine.length}`);
+});
+it("isWebSearchEnabled is false without a Tavily key", () => {
+  assert.equal(isWebSearchEnabled(), false);
 });
 
 console.log("");

--- a/src/ai/chain.js
+++ b/src/ai/chain.js
@@ -45,6 +45,11 @@ const {
   buildEmojiPromptBlock,
 } = require("./emoji-resolver");
 const {
+  WEB_SEARCH_TOOL,
+  isWebSearchEnabled,
+  makeToolCallHandler,
+} = require("./web-search");
+const {
   callGemini,
   callGroq,
   callDeepSeek,
@@ -107,6 +112,12 @@ function buildGuildChain(guildId, tierConfig) {
     return { chain: FALLBACK_CHAIN, rateLimited: false };
   }
 
+  // Web search is offered only on the DeepSeek (primary) entries; Groq/Gemini
+  // fallbacks answer without it. guildId is baked into the handler for quota.
+  const toolOpts = isWebSearchEnabled()
+    ? { tools: [WEB_SEARCH_TOOL], onToolCall: makeToolCallHandler(guildId) }
+    : {};
+
   const tierKey = tierConfig?.tier || "brief";
   const needsPro = TIER_REQUIRES_KEY[tierKey];
   const hasOwnKey = hasGuildApiKey(guildId);
@@ -123,6 +134,7 @@ function buildGuildChain(guildId, tierConfig) {
             apiKey: guildKey,
             model: DEEPSEEK_MODEL,
             reasoningHeadroom: DEEPSEEK_REASONING_HEADROOM,
+            ...toolOpts,
           }),
       };
       return { chain: [entry, ...FALLBACK_CHAIN], rateLimited: false };
@@ -130,7 +142,8 @@ function buildGuildChain(guildId, tierConfig) {
     if (isWhitelisted && DEEPSEEK_API_KEY) {
       const entry = {
         label: `deepseek:${DEEPSEEK_MODEL}`,
-        call: callDeepSeek,
+        call: (turns, persona, maxTokens) =>
+          callDeepSeek(turns, persona, maxTokens, { ...toolOpts }),
       };
       return { chain: [entry, ...FALLBACK_CHAIN], rateLimited: false };
     }
@@ -158,6 +171,7 @@ function buildGuildChain(guildId, tierConfig) {
       callDeepSeek(turns, persona, maxTokens, {
         model: DEEPSEEK_MODEL_FREE,
         reasoningHeadroom: 0,
+        ...toolOpts,
       }),
   };
   return { chain: [entry, ...FALLBACK_CHAIN], rateLimited: false };

--- a/src/ai/providers.js
+++ b/src/ai/providers.js
@@ -162,49 +162,94 @@ async function callGroq(turns, model, persona, maxTokens) {
   });
 }
 
+// Max rounds the model may call tools before it MUST answer. After this many
+// rounds we stop offering `tools`, forcing a text reply (and capping latency /
+// token spend). Each round is its own AI_TIMEOUT_MS-bounded request.
+const MAX_TOOL_ROUNDS = 2;
+
+// `overrides.tools` (OpenAI tool specs) + `overrides.onToolCall(name, args)`
+// (async → string) enable web search. When absent, this behaves exactly like a
+// plain single-shot chat completion. Only DeepSeek wires tools today.
 async function callDeepSeek(turns, persona, maxTokens, overrides = {}) {
   const model = overrides.model || DEEPSEEK_MODEL;
   const apiKey = overrides.apiKey || DEEPSEEK_API_KEY;
   const headroom = overrides.reasoningHeadroom ?? DEEPSEEK_REASONING_HEADROOM;
-
-  const body = {
-    model,
-    messages: buildOpenAIMessages(turns, persona),
-    temperature: 0.9,
-    top_p: 0.95,
-    max_tokens: maxTokens + headroom,
-  };
+  const tools = overrides.tools;
+  const onToolCall = overrides.onToolCall;
   const label = `deepseek:${model}`;
 
-  return withAbortTimeout(AI_TIMEOUT_MS, label, async (signal) => {
-    const response = await fetch("https://api.deepseek.com/chat/completions", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify(body),
-      signal,
+  const messages = buildOpenAIMessages(turns, persona);
+
+  for (let round = 0; ; round++) {
+    const offerTools = Boolean(tools && onToolCall && round < MAX_TOOL_ROUNDS);
+    const body = {
+      model,
+      messages,
+      temperature: 0.9,
+      top_p: 0.95,
+      max_tokens: maxTokens + headroom,
+    };
+    if (offerTools) body.tools = tools;
+
+    const res = await withAbortTimeout(AI_TIMEOUT_MS, label, async (signal) => {
+      const response = await fetch("https://api.deepseek.com/chat/completions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify(body),
+        signal,
+      });
+
+      logRateHeaders(label, response);
+
+      if (!response.ok) {
+        const errText = await response.text().catch(() => "");
+        const f = classifyHttpFailure(response, errText);
+        console.warn(`[ai] ${label} http ${response.status} kind=${f.kind}: ${errText.slice(0, 200)}`);
+        return f;
+      }
+
+      const payload = await response.json();
+      return { ok: true, choice: payload?.choices?.[0] };
     });
 
-    logRateHeaders(label, response);
+    if (!res.ok) return res;
 
-    if (!response.ok) {
-      const errText = await response.text().catch(() => "");
-      const f = classifyHttpFailure(response, errText);
-      console.warn(`[ai] ${label} http ${response.status} kind=${f.kind}: ${errText.slice(0, 200)}`);
-      return f;
+    const choice = res.choice;
+    const msg = choice?.message;
+    const toolCalls = msg?.tool_calls;
+
+    // Model wants to search: run each tool, append results, loop for the answer.
+    if (offerTools && Array.isArray(toolCalls) && toolCalls.length > 0) {
+      messages.push(msg);
+      for (const tc of toolCalls) {
+        let result;
+        try {
+          const args = JSON.parse(tc?.function?.arguments || "{}");
+          result = await onToolCall(tc?.function?.name, args);
+        } catch (err) {
+          result = `（工具呼叫失敗：${err.message}）`;
+        }
+        messages.push({
+          role: "tool",
+          tool_call_id: tc.id,
+          content: typeof result === "string" ? result : String(result ?? ""),
+        });
+      }
+      console.log(`[ai] ${label} ran ${toolCalls.length} tool call(s) round=${round}`);
+      continue;
     }
 
-    const payload = await response.json();
-    const text = payload?.choices?.[0]?.message?.content?.trim();
+    const text = msg?.content?.trim();
     if (!text) {
-      const finishReason = payload?.choices?.[0]?.finish_reason ?? "unknown";
+      const finishReason = choice?.finish_reason ?? "unknown";
       console.warn(`[ai] ${label} empty response, finishReason=${finishReason}`);
       return fail("empty", { detail: finishReason });
     }
     return ok(text);
-  });
+  }
 }
 
 module.exports = {

--- a/src/ai/web-search.js
+++ b/src/ai/web-search.js
@@ -1,0 +1,137 @@
+// Web search for 西寶 — Tavily backend, exposed to DeepSeek via OpenAI
+// tool-calling. DeepSeek's API has NO native web access (only the consumer app
+// does), so this module is the actual "go online" half: the model decides WHEN
+// to look something up (emits a `web_search` tool call), and we run the Tavily
+// query here and feed the snippets back. Only DeepSeek/Groq (OpenAI-compatible)
+// can call it; Gemini fallback answers without search.
+//
+// Quota is double-capped (per-guild + global daily) so a free Tavily key can't
+// be drained. Caps reuse rate-limiter with `web:` prefixed keys so they don't
+// collide with the DeepSeek free-tier counter.
+
+const {
+  TAVILY_API_KEY,
+  WEB_SEARCH_MAX_RESULTS,
+  WEB_SEARCH_DAILY_LIMIT_GUILD,
+  WEB_SEARCH_DAILY_LIMIT_GLOBAL,
+  WEB_SEARCH_TIMEOUT_MS,
+} = require("../config");
+const { checkAndIncrement } = require("./rate-limiter");
+
+// OpenAI-compatible tool spec handed to DeepSeek. Terse on purpose — the model
+// only needs to know it CAN look things up and must pass a focused query, not
+// the whole sentence. The "閒聊時不要用" line keeps 西寶 from searching banter.
+const WEB_SEARCH_TOOL = {
+  type: "function",
+  function: {
+    name: "web_search",
+    description:
+      "查網路上的即時／事實資訊（新聞、現況、比賽結果、你不確定或可能過時的東西）。純閒聊、講感受、開玩笑、對方只是在跟你互動時不要用。",
+    parameters: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "精簡的搜尋關鍵字（不是整句話），用最可能查到答案的語言",
+        },
+      },
+      required: ["query"],
+    },
+  },
+};
+
+function isWebSearchEnabled() {
+  return Boolean(TAVILY_API_KEY);
+}
+
+// Format Tavily's JSON into a compact text block for the tool result. Pure so
+// it's unit-testable without a network call.
+function formatTavilyResults(payload, query) {
+  const out = [];
+  const answer = (payload?.answer || "").trim();
+  if (answer) out.push(`摘要：${answer}`);
+
+  const results = Array.isArray(payload?.results) ? payload.results : [];
+  results.slice(0, WEB_SEARCH_MAX_RESULTS).forEach((r, i) => {
+    const title = (r?.title || "").trim();
+    const content = (r?.content || "").replace(/\s+/g, " ").trim().slice(0, 400);
+    const url = (r?.url || "").trim();
+    const parts = [`[${i + 1}] ${title}`.trim()];
+    if (content) parts.push(content);
+    if (url) parts.push(`(${url})`);
+    out.push(parts.join("\n"));
+  });
+
+  if (out.length === 0) return `（找不到「${query}」的相關結果）`;
+  return out.join("\n\n");
+}
+
+async function runWebSearch(query, guildId) {
+  const cleanQuery = String(query || "").replace(/\s+/g, " ").trim().slice(0, 300);
+  if (!cleanQuery) return "（沒有提供搜尋關鍵字）";
+  if (!TAVILY_API_KEY) return "（沒設定搜尋功能，沒辦法上網查）";
+
+  // Double daily cap — global first so one guild can't starve others by racing,
+  // then per-guild. Both use the shared rate-limiter under web: keys.
+  if (!checkAndIncrement("web:global", WEB_SEARCH_DAILY_LIMIT_GLOBAL).allowed) {
+    console.log("[web-search] global daily limit hit");
+    return "（今天整體的搜尋次數用完了，晚點再查）";
+  }
+  if (guildId && !checkAndIncrement(`web:${guildId}`, WEB_SEARCH_DAILY_LIMIT_GUILD).allowed) {
+    console.log(`[web-search] guild=${guildId} daily limit hit`);
+    return "（這個群今天的搜尋次數用完了）";
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), WEB_SEARCH_TIMEOUT_MS);
+  try {
+    const response = await fetch("https://api.tavily.com/search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        api_key: TAVILY_API_KEY,
+        query: cleanQuery,
+        search_depth: "basic",
+        include_answer: true,
+        max_results: WEB_SEARCH_MAX_RESULTS,
+      }),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      const errText = await response.text().catch(() => "");
+      console.warn(`[web-search] tavily http ${response.status}: ${errText.slice(0, 200)}`);
+      return `（搜尋失敗：${response.status}）`;
+    }
+    const payload = await response.json();
+    console.log(
+      `[web-search] query="${cleanQuery}" results=${payload?.results?.length ?? 0}`,
+    );
+    return formatTavilyResults(payload, cleanQuery);
+  } catch (err) {
+    if (err?.name === "AbortError") {
+      console.warn(`[web-search] timed out after ${WEB_SEARCH_TIMEOUT_MS}ms`);
+      return "（搜尋逾時了）";
+    }
+    console.warn(`[web-search] failed: ${err.message}`);
+    return `（搜尋出錯了：${err.message}）`;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Dispatcher passed into the provider tool loop. Bakes guildId in for quota so
+// the provider layer stays ignorant of guild context.
+function makeToolCallHandler(guildId) {
+  return async (name, args) => {
+    if (name === "web_search") return runWebSearch(args?.query, guildId);
+    return `（未知的工具：${name}）`;
+  };
+}
+
+module.exports = {
+  WEB_SEARCH_TOOL,
+  isWebSearchEnabled,
+  runWebSearch,
+  formatTavilyResults,
+  makeToolCallHandler,
+};

--- a/src/config.js
+++ b/src/config.js
@@ -149,6 +149,14 @@ module.exports = {
   AI_LONG_TERM_MEMORY_ENABLED:
     (process.env.AI_LONG_TERM_MEMORY_ENABLED || "true").toLowerCase() === "true",
   EMOJI_TRUSTED_GUILD_IDS: parseCsvEnv("EMOJI_TRUSTED_GUILD_IDS"),
+  // Web search (Tavily) — exposed to DeepSeek via tool-calling. Empty key = off.
+  // Daily caps are conservative so a free Tavily key (~1000/month) can't drain:
+  // 30 global/day ≈ 900/month. Raise via env once on a paid plan.
+  TAVILY_API_KEY: process.env.TAVILY_API_KEY,
+  WEB_SEARCH_MAX_RESULTS: parsePositiveIntEnv("WEB_SEARCH_MAX_RESULTS", 5),
+  WEB_SEARCH_DAILY_LIMIT_GUILD: parsePositiveIntEnv("WEB_SEARCH_DAILY_LIMIT_GUILD", 15),
+  WEB_SEARCH_DAILY_LIMIT_GLOBAL: parsePositiveIntEnv("WEB_SEARCH_DAILY_LIMIT_GLOBAL", 30),
+  WEB_SEARCH_TIMEOUT_MS: parsePositiveIntEnv("WEB_SEARCH_TIMEOUT_MS", 8000),
   AI_PERSONA: process.env.AI_PERSONA || DEFAULT_AI_PERSONA,
   DEFAULT_AI_PERSONA,
   THREADS_EMBED_COLOR: 0x101010,


### PR DESCRIPTION
## 背景

接續 Discord-thread 回饋的**問題 4**：西寶說「等等來看一下是啥」但其實沒聯網能力。查證後確認 DeepSeek **API**（非 App）沒有原生網路搜尋，所以用 tool-calling + Tavily 後端補上。

## 設計

DeepSeek 判斷需要 → 吐 `web_search` 工具呼叫 → 我們跑 Tavily → 結果餵回 → DeepSeek 用結果回答。

- **`src/ai/web-search.js`（新）**：Tavily client + `WEB_SEARCH_TOOL` + `runWebSearch` + `makeToolCallHandler`。雙重每日上限（`web:global` + `web:<guild>`，沿用 rate-limiter 另開 namespace），免費 key（~1000/月）不會被刷爆。
- **`providers.js`**：`callDeepSeek` 多一段 tool loop（`MAX_TOOL_ROUNDS=2`）。沒給 tools → 行為與原本逐字相同。Groq/Gemini 不動（fallback 不搜）。
- **`chain.js`**：`buildGuildChain` 只在 DeepSeek entries 掛上工具 + per-guild handler，由 `isWebSearchEnabled()`（有無 `TAVILY_API_KEY`）控制。
- **`config.js`**：`TAVILY_API_KEY` + `WEB_SEARCH_*`（保守上限，預設關閉）。

**預設關閉**：沒設 key → 不送 tools → 行為不變，可安全合併、之後再加 key 開啟。

## 啟用步驟（合併後）
1. [tavily.com](https://tavily.com) 註冊拿 key（免費 ~1000/月）。
2. host 的 `.env` 加 `TAVILY_API_KEY=tvly-...`。
3. 重啟 bot（見 deploy.md）。

## 測試
- `npm test` 全綠：pure **169** / routing **28** / circuit **46**。
- +10 cases：`formatTavilyResults`（純）、tool spec、`runWebSearch` 空查詢/無 key、handler dispatch、`callDeepSeek` tool loop（搜尋→餵回→回答）、plain completion 不送 tools。
- ⚠️ 真實 Tavily + DeepSeek 串接需設 key 後 shadow-deploy 實測。

## 注意
與 #38 在 `chain.js` / `config.js` 有少量重疊（不同區塊）。若 #38 先合併，這條 rebase 會有 trivial conflict。

🤖 Generated with [Claude Code](https://claude.com/claude-code)