### PR TITLE
fix: surface replied-to message + record scheduled posts into memory

### DIFF
--- a/scripts/smoke.js
+++ b/scripts/smoke.js
@@ -35,6 +35,7 @@ const { buildUserTurn, buildOpenAIMessages, buildGeminiContents } =
 const {
   formatGroupMessage,
   buildGroupContextBlock,
+  buildReplyContextBlock,
 } = require("../src/ai/group-context");
 const {
   detectImitationIntent,
@@ -576,6 +577,28 @@ it("wraps lines under header", () => {
   assert.match(out, /^\n\n## 最近群組對話/);
   assert.ok(out.includes("[a]: hi"));
   assert.ok(out.includes("[b]: yo"));
+});
+
+console.log("buildReplyContextBlock");
+it("returns empty string when there is no content", () => {
+  assert.equal(buildReplyContextBlock(), "");
+  assert.equal(buildReplyContextBlock({ content: "" }), "");
+  assert.equal(buildReplyContextBlock({ content: "   " }), "");
+});
+it("marks the bot's own post as self-authored", () => {
+  const out = buildReplyContextBlock({ content: "今天好熱鬧", isSelf: true });
+  assert.ok(out.includes("你自己稍早"));
+  assert.ok(out.includes("今天好熱鬧"));
+});
+it("attributes someone else's post by name", () => {
+  const out = buildReplyContextBlock({
+    content: "蟑螂",
+    authorName: "濤濤",
+    isSelf: false,
+  });
+  assert.ok(out.includes("濤濤稍早"));
+  assert.ok(out.includes("蟑螂"));
+  assert.ok(!out.includes("你自己"));
 });
 
 console.log("ai-memory");

--- a/src/ai/chain.js
+++ b/src/ai/chain.js
@@ -13,13 +13,14 @@ const {
   DEEPSEEK_PREMIUM_GUILD_IDS,
   DEEPSEEK_REASONING_HEADROOM,
 } = require("../config");
-const { trimDescription } = require("../utils");
+const { trimDescription, sanitizeName } = require("../utils");
 const { getTierConfig, TIER_REQUIRES_KEY } = require("../tier-config");
 const { buildUserTurn } = require("./persona");
 const { getChannelAIHistory, recordAITurn } = require("./memory");
 const {
   fetchGroupContext,
   buildGroupContextBlock,
+  buildReplyContextBlock,
 } = require("./group-context");
 const {
   detectImitationIntent,
@@ -305,9 +306,38 @@ async function generateAIReply(message, userText) {
     }
   }
 
-  // Inject group context at the front (topic awareness) and the target block
-  // right before the user turn (closest to the request). We deliberately KEEP
-  // group context on imitation turns: the user wants "imitate me about the
+  // Discord reply reference: when the @ is itself a reply to a specific message,
+  // that message is the explicit referent of "你剛剛說的" / "這個". Resolve it so
+  // 西寶 can see what's being replied to — crucial for replies to her OWN
+  // scheduled posts (daily recap / bedtime story), which never enter conv memory
+  // and are filtered out of group context (it drops the bot's own messages).
+  let replyBlock = "";
+  if (message.reference?.messageId && typeof message.fetchReference === "function") {
+    try {
+      const ref = await message.fetchReference();
+      const refContent = (ref.content || "").trim();
+      if (refContent) {
+        const isSelf = ref.author?.id === message.client?.user?.id;
+        const authorName = sanitizeName(
+          ref.member?.displayName ||
+            ref.author?.globalName ||
+            ref.author?.username,
+        );
+        replyBlock = buildReplyContextBlock({
+          content: trimDescription(refContent, 500),
+          authorName,
+          isSelf,
+        });
+      }
+    } catch (err) {
+      // Referenced message deleted / unfetchable — skip silently.
+      console.log(`[ai] reply reference unresolved: ${err.message}`);
+    }
+  }
+
+  // Inject group context at the front (topic awareness); target block and reply
+  // block right before the user turn (closest to the request). We deliberately
+  // KEEP group context on imitation turns: the user wants "imitate me about the
   // current topic" (e.g. comment on the football chat in my voice), so the
   // topic must stay visible. Dropping any ongoing roleplay CHARACTER is the job
   // of the target block's instruction, not of hiding the context.
@@ -316,6 +346,9 @@ async function generateAIReply(message, userText) {
   }
   if (targetBlock) {
     turns.splice(turns.length - 1, 0, { role: "user", content: targetBlock });
+  }
+  if (replyBlock) {
+    turns.splice(turns.length - 1, 0, { role: "user", content: replyBlock });
   }
 
   const result = await runProviderChain(
@@ -345,7 +378,7 @@ async function generateAIReply(message, userText) {
     });
     const isPremium = hasGuildApiKey(message.guildId) || DEEPSEEK_PREMIUM_GUILD_IDS.includes(message.guildId);
     console.log(
-      `[ai] used ${result.provider.label} tier=${tierConfig.tier} premium=${isPremium} len=${result.text.length} history_before=${history.length} group_ctx=${groupContextSize} target_ctx=${targetCtxSize} roster=${roster.length} profile=${profileBlock ? 1 : 0}`,
+      `[ai] used ${result.provider.label} tier=${tierConfig.tier} premium=${isPremium} len=${result.text.length} history_before=${history.length} group_ctx=${groupContextSize} target_ctx=${targetCtxSize} reply_ctx=${replyBlock ? 1 : 0} roster=${roster.length} profile=${profileBlock ? 1 : 0}`,
     );
 
     if (AI_LONG_TERM_MEMORY_ENABLED) {

--- a/src/ai/group-context.js
+++ b/src/ai/group-context.js
@@ -82,8 +82,21 @@ function buildGroupContextBlock(entries) {
   return `\n\n## 最近群組對話 (供你了解 context, 不要直接複述)\n${lines.join("\n")}`;
 }
 
+// Renders the message a reply points at into a context turn. The bot's own
+// scheduled posts (recap / bedtime story) never enter conv memory and are
+// filtered out of group context, so when someone REPLIES to one this is the
+// only way 西寶 sees what she's being asked about. `isSelf` makes her own
+// authorship explicit so she owns the post instead of playing dumb.
+function buildReplyContextBlock({ content, authorName, isSelf } = {}) {
+  const text = (content || "").trim();
+  if (!text) return "";
+  const who = isSelf ? "你自己稍早" : `${authorName || "某人"}稍早`;
+  return `## 對方正在回覆的訊息\n（${who}說過：「${text}」。對方這句話是在回應這段，請據此理解，別當作沒看過。）`;
+}
+
 module.exports = {
   fetchGroupContext,
   formatGroupMessage,
   buildGroupContextBlock,
+  buildReplyContextBlock,
 };

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -4,6 +4,7 @@ const { getAllSchedules, getScheduleById, updateSchedule } = require("./schedule
 const { getTierConfig } = require("./tier-config");
 const { trimDescription } = require("./utils");
 const { AI_PROVIDER_CHAIN, runProviderChain } = require("./ai/chain");
+const { recordAITurn } = require("./ai/memory");
 const {
   buildEmojiMap,
   buildEmojiPromptBlock,
@@ -170,6 +171,20 @@ async function executeScheduledTask(schedule, client) {
     const capped = trimDescription(result.text, tierConfig.maxReplyChars);
     const text = resolveCustomEmojis(capped, emojiMap);
     const sent = await channel.send({ content: text });
+
+    // Record this post into the channel's short-term memory as an assistant
+    // turn so that when someone @s or replies to 西寶 shortly after, she
+    // remembers having posted it — otherwise scheduled posts leave zero trace
+    // in conv memory and she "plays dumb" about her own recap / story. Store
+    // the UNRESOLVED `capped` text (`:name:` form), same reasoning as
+    // ai/chain.js. No user turn is recorded — the prompt is a system
+    // instruction, not a member's message.
+    recordAITurn(channelId, "assistant", capped, tierConfig.memoryMaxTurns, {
+      guildId,
+      userId: client.user?.id,
+      displayName: client.user?.username || "西寶",
+    });
+
     if (typeof onSuccess === "function") {
       try {
         onSuccess({ text, sent });


### PR DESCRIPTION
## Problem

When someone @s or replies to 西寶 about something she posted (a daily recap or bedtime story), she "played dumb" — she couldn't acknowledge her own post. Two independent gaps in the reply path caused it:

1. **Scheduled posts never entered conversation memory.** `executeScheduledTask` sends via `channel.send()` but never called `recordAITurn`, so `daily_recap` / `bedtime_story` left zero trace in `aiConversationHistory`.
2. **Discord reply references were never resolved.** Nothing in the AI path read `message.reference`, so the one explicit pointer to "the message I'm replying to" was discarded. Group context also filters out the bot's own messages, so it couldn't recover the post that way either.

## Fix

- **scheduler.js** — record each scheduled post as an assistant turn (unresolved `:name:` emoji form, no user turn) so same-channel replies within the memory TTL see it.
- **chain.js** — resolve `message.reference` via `fetchReference()` and inject the referenced message as a user-role context turn closest to the user turn; self-authored posts are marked explicitly so 西寶 owns them. Adds `reply_ctx` to the `[ai]` log line.
- **group-context.js** — new pure `buildReplyContextBlock` helper (+ smoke tests).

Reply-reference resolution is the robust half: it works regardless of memory TTL, restarts, or which channel the post was in.

## Tests

`npm test` — 178 + 28 + 40 pass (3 new `buildReplyContextBlock` cases in the pure layer).

## Note

Based on `origin/main`; does **not** include the in-flight `feat/kimi-provider` branch. `chain.js` will have a small, auto-mergeable interaction (different lines in the import block + `generateAIReply`) when both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
