### PR TITLE
fix: MIXED Threads posts keep carousel AND unfurl a playable video

### DIFF
--- a/.claude/rules/routing.md
+++ b/.claude/rules/routing.md
@@ -7,7 +7,7 @@ Top-level dispatcher: [src/preview.js](../../src/preview.js). Per-platform build
 | Condition | Output |
 |---|---|
 | No image **AND** no video (`isTextOnly`) or `twitterCard === "summary"` | Custom embed (text only) |
-| Multiple images (`imageCount > 1`) | Multi-image carousel embed — 顯示前 `MULTI_IMAGE_PREVIEW_COUNT` 張（default 3）。若被截斷 或 `hasVideo`，最後一個 embed 的 description 追加提示（e.g. `... 還有 6 張 + 影片`）。沒有 button — 原本每個 embed 的標題就連回原貼文。檢查順序早於 video，混合 image+video 仍走 carousel |
+| Multiple images (`imageCount > 1`) | Multi-image carousel embed — 顯示前 `MULTI_IMAGE_PREVIEW_COUNT` 張（default 3）。若被截斷，最後一個 embed 的 description 追加提示（e.g. `... 還有 6 張`）。沒有 button — 原本每個 embed 的標題就連回原貼文。檢查順序早於 video；混合 image+video 走 carousel **並**把 fixer URL 放進 `content`，Discord 在圖集下方 unfurl 可播放影片（影片不再變靜態截圖，所以提示也不再追加 `+ 影片`） |
 | Has video / `videoCount > 0` (regardless of og:image presence) | Primary fixer (`FIXER_THREADS`) → secondary fixer (`FIXER_THREADS_SECONDARY`) → embedFallback (compact embed with description + 「影片無法載入」note) → OG recovery (lazy fetch fixer URLs) |
 | `summary_large_image` + single image | Custom embed with image |
 | Generic / partial metadata | Compact text embed |
@@ -15,7 +15,7 @@ Top-level dispatcher: [src/preview.js](../../src/preview.js). Per-platform build
 
 **Order is load-bearing.** See [src/platforms/threads.js](../../src/platforms/threads.js) — the `if` ladder order determines which branch a mixed (image+video) post falls into. Hard-asserted by [scripts/routing-smoke.js](../../scripts/routing-smoke.js):
 
-- **MIXED case** (multi-image AND video → carousel wins, NOT video fixer)
+- **MIXED case** (multi-image AND video → carousel gallery kept AND fixer URL attached as `content` for a playable video unfurl — NOT dropped to a bare video fixer that loses the images)
 - **VIDEO-NO-IMAGE case** (video with `image=null` MUST still route to fixer chain — was a regression where `isTextOnly = !metadata.image` silently dropped these to text embed)
 
 `isTextOnly` requires NO image AND NO video. A video-only post without `og:image` previously fell into the text-only branch and silently dropped the video.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ CommonJS modules under `src/`. Entry point [src/index.js](src/index.js) is just 
 ## Core gotchas (load-bearing — won't be obvious from code alone)
 
 - **Mention text → `.normalize("NFC")` before comparison.** Discord can send CJK input in NFD form, causing strict equality (e.g. `抽籤`) to silently fail.
-- **Threads routing order in `buildPreviewPayloads` is load-bearing.** The `if` ladder order determines which branch a mixed (image + video) post falls into. Hard-asserted by `scripts/routing-smoke.js` (MIXED case). Run `npm run test:routing` before merging any reorder.
+- **Threads routing order in `buildPreviewPayloads` is load-bearing.** The `if` ladder order determines which branch a mixed (image + video) post falls into — multi-image is checked before video, so a MIXED post stays a carousel gallery AND attaches the fixer URL as `content` (Discord unfurls a playable video below the gallery), rather than dropping to a bare video fixer that loses the images. Hard-asserted by `scripts/routing-smoke.js` (MIXED case). Run `npm run test:routing` before merging any reorder.
 - **`normalizeUrl` tracking-param lists are NOT interchangeable.** `t` is a tracking param on X/Twitter but a timestamp on YouTube — that's why there's a `HOST_GATED_TRACKING_PARAMS` list. When adding a param, decide if it's meaningful on any supported host and gate accordingly.
 - **`inFlightReplies` Set uses two key formats** (`msgId:urls...` and `mention:msgId`) because Discord gateway reconnects can fire `messageCreate` twice — without dedup, the mention path would produce both an AI reply and a fallback reply for the same message.
 - **AI chain failures are silent by design.** Each provider failure (network, timeout, safety block, empty candidate) returns a `{ ok: false, kind }` and moves to the next layer. The ops signal is the single log line `[ai] chain exhausted (X providers tried), falling back to hardcoded reply` — grep for it when debugging a dead 西寶.
@@ -29,7 +29,7 @@ CommonJS modules under `src/`. Entry point [src/index.js](src/index.js) is just 
 
 ## Key behavioural summary
 
-- **Threads**: text-only (no image AND no video) → custom embed. Video (with or without og:image) → fixer link with secondary + OG recovery. Single image → custom embed. Multiple images → carousel of 前 `MULTI_IMAGE_PREVIEW_COUNT` 張（default 3）；截斷或含 video 時最後一個 embed description 追加 `... 還有 N 張 + 影片` 提示。Probe error → primary + secondary fixer + OG recovery list (no longer just dropping to a single fixer). Full decision table in [routing.md](.claude/rules/routing.md).
+- **Threads**: text-only (no image AND no video) → custom embed. Video (with or without og:image) → fixer link with secondary + OG recovery. Single image → custom embed. Multiple images → carousel of 前 `MULTI_IMAGE_PREVIEW_COUNT` 張（default 3）；截斷時最後一個 embed description 追加 `... 還有 N 張` 提示。含 video 的混合貼文額外把 fixer URL 放進 `content`，讓 Discord 在圖集下方 unfurl 可播放影片（carousel 是保底、影片是加碼，不再把影片變成靜態截圖）。Probe error → primary + secondary fixer + OG recovery list (no longer just dropping to a single fixer). Full decision table in [routing.md](.claude/rules/routing.md).
 - **Bilibili**: API-first via `https://api.bilibili.com/x/web-interface/view` (already in code, now wired). Success → custom embed. Failure → vxbilibili fixer + OG recovery.
 - **Instagram Stories**: no fixer works — bot replies with owner username in 西寶 voice and skips the embed-check pipeline entirely.
 - **Everything else (X/Twitter / Reddit / Pixiv / Bluesky / Facebook)**: fixer host as primary with `recoverUrls` for OG-recovery if unfurl is empty.

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ docker run -d \
 |---|---|
 | 純文字 | 自訂 embed（標題＋內文） |
 | 單張圖片 | 自訂 embed（標題＋內文＋圖片） |
-| 多張圖片 | 全圖集 embed（每張圖各一個 embed，Discord 渲染成 gallery） |
+| 多張圖片 | 全圖集 embed（每張圖各一個 embed，Discord 渲染成 gallery）。含影片的混合貼文會在圖集下方額外附上可播放影片 |
 | 影片 | 依序嘗試 fixthreads → threadsez → 資訊卡 fallback |
 
 ### Instagram

--- a/scripts/routing-smoke.js
+++ b/scripts/routing-smoke.js
@@ -183,29 +183,55 @@ const THREADS_URL = "https://www.threads.net/@a/post/1";
     );
   });
 
-  // CRITICAL CASE — this is the regression that bit twice in PR #15.
-  await it("MIXED: multi-image AND video → carousel wins (NOT video fixer)", async () => {
+  // CRITICAL CASE (regression that bit twice in PR #15): a MIXED post must KEEP
+  // the image carousel — images must never be dropped for a bare video fixer. It
+  // now ALSO attaches the fixer URL as content so Discord unfurls a playable
+  // video below the gallery (both, not either/or). Uses 5 images to also assert
+  // the image-truncation hint survives and no longer announces "影片".
+  await it("MIXED: multi-image AND video → carousel gallery + playable video unfurl", async () => {
     _mockThreadsMetadata = {
       image: "https://x/1.jpg",
       title: "t",
       description: "d",
       twitterCard: "summary_large_image",
-      images: ["https://x/1.jpg", "https://x/2.jpg"],
-      imageCount: 2,
+      images: [
+        "https://x/1.jpg",
+        "https://x/2.jpg",
+        "https://x/3.jpg",
+        "https://x/4.jpg",
+        "https://x/5.jpg",
+      ],
+      imageCount: 5,
       videoCount: 1,
       video: true,
     };
     const p = await buildThreadsPayload(THREADS_URL);
     const s = shapeOf(p);
-    assert.equal(s.embedCount, 2, "should produce 2 carousel embeds");
-    assert.equal(s.hasContent, false, "MUST NOT route to video fixer");
+    // gallery preserved (truncated to the preview count)...
+    assert.equal(s.embedCount, 3, "keeps the image carousel (truncated to 3)");
+    // ...AND the video is handed to Discord as a content URL for a real player
+    assert.equal(
+      s.hasContent,
+      true,
+      "attaches fixer URL so Discord unfurls a playable video",
+    );
+    assert.equal(s.contentStartsWithHttp, true);
+    assert.ok(
+      s.contentText.includes("fixthreads"),
+      "video unfurl uses the primary fixer",
+    );
+    // no legacy video-fixer fallback chain — the carousel is the guaranteed floor
     assert.equal(s.hasFallbackContent, false);
     assert.equal(s.hasEmbedFallback, false);
-    assert.equal(s.hasComponents, false, "no button — description hint only");
+    assert.equal(s.hasComponents, false);
     const lastDesc = p.embeds[p.embeds.length - 1].data?.description;
     assert.ok(
-      typeof lastDesc === "string" && lastDesc.includes("影片"),
-      `last embed should hint video presence, got: ${lastDesc}`,
+      typeof lastDesc === "string" && lastDesc.includes("還有 2 張"),
+      `last embed should still hint remaining images, got: ${lastDesc}`,
+    );
+    assert.ok(
+      !/影片/.test(lastDesc || ""),
+      `hint must NOT announce 影片 now that it unfurls, got: ${lastDesc}`,
     );
   });
 

--- a/src/platforms/threads.js
+++ b/src/platforms/threads.js
@@ -51,6 +51,18 @@ async function buildThreadsPayload(url) {
     }
 
     if (metadata.imageCount > 1) {
+      // MIXED (multi-image + video): keep the image gallery AND hand Discord the
+      // fixer URL as message content, so it unfurls a *playable* video below the
+      // gallery instead of the carousel eating the video as a static poster
+      // frame. The pre-rendered carousel is the guaranteed floor — with `embeds`
+      // present, discord-io marks the payload not-url-only, so it suppresses
+      // immediately and skips the empty-embed delete; the video unfurl is a pure
+      // bonus that either renders or silently doesn't. Because the video is now
+      // shown for real, the tail hint no longer announces "+ 影片".
+      const videoContent = hasVideo
+        ? replaceHostFixer(url, FIXER_THREADS)
+        : undefined;
+
       const allImages =
         metadata.images && metadata.images.length > 1
           ? metadata.images.slice(0, 10)
@@ -62,11 +74,12 @@ async function buildThreadsPayload(url) {
           0,
           (metadata.imageCount || allImages.length) - previewImages.length,
         );
-        const tailHint = buildTailHint(hiddenImages, Boolean(hasVideo));
+        const tailHint = buildTailHint(hiddenImages, false);
         console.log(
-          `[preview] threads-multi-image carousel count=${previewImages.length}/${allImages.length} hasVideo=${Boolean(hasVideo)} hint=${tailHint ? `"${tailHint}"` : "none"} ${url}`,
+          `[preview] threads-multi-image carousel count=${previewImages.length}/${allImages.length} hasVideo=${Boolean(hasVideo)} videoUnfurl=${Boolean(videoContent)} hint=${tailHint ? `"${tailHint}"` : "none"} ${url}`,
         );
         return {
+          ...(videoContent ? { content: videoContent } : {}),
           embeds: buildThreadsCarouselEmbeds(
             url,
             metadata,
@@ -78,7 +91,7 @@ async function buildThreadsPayload(url) {
       const fallbackEmbed = buildThreadsMediaEmbed(url, metadata);
       const fallbackHint = buildTailHint(
         Math.max(0, (metadata.imageCount || 1) - 1),
-        Boolean(hasVideo),
+        false,
       );
       if (fallbackHint) {
         const existing = fallbackEmbed.data?.description;
@@ -87,9 +100,12 @@ async function buildThreadsPayload(url) {
         );
       }
       console.log(
-        `[preview] threads-multi-image fallback hasVideo=${Boolean(hasVideo)} hint=${fallbackHint ? `"${fallbackHint}"` : "none"} ${url}`,
+        `[preview] threads-multi-image fallback hasVideo=${Boolean(hasVideo)} videoUnfurl=${Boolean(videoContent)} hint=${fallbackHint ? `"${fallbackHint}"` : "none"} ${url}`,
       );
-      return { embeds: [fallbackEmbed] };
+      return {
+        ...(videoContent ? { content: videoContent } : {}),
+        embeds: [fallbackEmbed],
+      };
     }
 
     if (metadata.video || metadata.videoCount > 0) {


### PR DESCRIPTION
## Problem

A Threads post with **multiple images + a video** hits the carousel branch (`imageCount > 1` is checked before the video branch), so the video was rendered as a **static poster frame** inside the image gallery — the video got "eaten" (screenshot instead of playable).

Observed on `@taiwan_ant/post/DaDWSe0kzJT` (`imageCount: 4, videoCount: 1`): bot.log shows `[preview] threads-multi-image carousel count=3/4 hasVideo=true` → gallery with the video as a still frame.

## Fix

For MIXED posts, the carousel payload now **also attaches the fixer URL as message `content`**, so Discord unfurls a **playable video below the gallery**. Verified both fixers serve a real player card for these posts (`twitter:card=player`, `og:video:type=video/mp4`): `fixthreads.seria.moe` (primary, used) and `fzthreads.com`.

Why this is safe with no changes to `discord-io.js` / `index.js`: a payload with `embeds` present keeps `isUrlOnly=false` (discord-io.js:152), so it suppresses immediately and **skips the empty-embed delete**. The pre-rendered carousel is the guaranteed floor; the video unfurl is a pure bonus that either renders or silently doesn't. The tail hint drops `+ 影片` since the video is now shown for real.

Pure multi-image (no video) is unchanged — `content` is only attached when `hasVideo`.

## Test

- `npm test` green (165 pure + 28 routing + 40 circuit, exit 0).
- Flips the `routing-smoke.js` MIXED hard-assert: was "carousel wins, `hasContent:false`, MUST NOT route to video fixer" → now "carousel gallery **kept** (`embedCount:3`) **AND** `content` = primary fixer URL, hint keeps `還有 2 張` but drops `影片`". Uses 5 images to also lock the truncation hint.

## Docs

`CLAUDE.md` (MIXED gotcha + behavioural summary), `.claude/rules/routing.md` (multi-image row + MIXED bullet), `README.md` (多張圖片 row).

## Note

Independent of [#45](https://github.com/Lanternko/discord-social-preview-bot/pull/45) (touches `threads.js` / `routing-smoke.js`, not `config.js` / `probe.js`). Being cherry-picked onto the deployed `feat/kimi-provider` for live testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)