### PR TITLE
feat: delete 西寶's message via 🗑️ reaction

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -13,6 +13,7 @@ CommonJS modules under `src/`. Entry point is [src/index.js](../../src/index.js)
 - **Platforms** — [platforms/](../../src/platforms/) holds one builder per platform (`threads.js`, `instagram.js`, `bilibili.js`, `bahamut.js`, `ptt.js`). Each returns a `{ content?, embeds?, fallbackContent?, embedFallback?, recoverUrls?, recoverEmbedOptions?, sourceUrl? }` payload. `recoverUrls` is the OG-fallback layer — list of URLs whose HTML to fetch + parse for OG tags when both primary and secondary fixer unfurl empty.
 - **Preview dispatcher** — [preview.js](../../src/preview.js) `buildPreviewPayloads` runs all per-URL builders in parallel via `Promise.all`. Per-platform branches dispatch to the correct builder; URL-only platforms (X/Reddit/Pixiv/Bluesky/Facebook) all share `buildSimpleFixerPayload` which always populates `recoverUrls`. The `if` ladder inside each platform builder is what's load-bearing — see [routing.md](routing.md).
 - **Discord I/O** — [discord-io.js](../../src/discord-io.js) handles send/suppress/empty-embed/dedup state/permissions.
+- **Reaction delete** — [reaction-delete.js](../../src/reaction-delete.js) is the `messageReactionAdd` handler: a 🗑️ reaction on one of 西寶's own messages deletes it, authorized by the link poster (via the reply reference) or a `ManageMessages` mod. No persistent state. See [routing.md](routing.md).
 - **Mention** — [mention.js](../../src/mention.js) is the `@西寶` dispatcher (抽籤 / 道歉 / AI / hardcoded fallback). See [persona.md](persona.md).
 - **Slash commands** — [commands.js](../../src/commands.js) registers and handles `/servers`, `/debug-perms`, `/ai-tier`, `/ai-key`, `/memory`, and `/schedule`. [tier-store.js](../../src/tier-store.js) persists `/ai-tier` to `data/tier-settings.json`; [tier-config.js](../../src/tier-config.js) does lookup + persona overlay (`getTierConfig(guildId)`).
 - **AI subsystem** — [ai/](../../src/ai/) is its own world. See [ai-providers.md](ai-providers.md) for the chain shape and circuit breaker.
@@ -52,6 +53,7 @@ src/
 │   ├── group-context.js  # Recent non-bot messages → user-role context turn (standard/detailed)
 │   └── chain.js          # buildAIProviderChain + runProviderChain + generateAIReply
 ├── mention.js            # @西寶 dispatcher (抽籤 / 道歉 / AI / hardcoded fallback)
+├── reaction-delete.js    # 🗑️ reaction on 西寶's own message → delete it (poster or ManageMessages)
 ├── commands.js           # Slash commands (/servers, /debug-perms, /ai-tier, /ai-key, /memory, /schedule)
 ├── tier-store.js         # Per-guild /ai-tier persistence (data/tier-settings.json)
 ├── tier-config.js        # Tier lookup + persona overlay — getTierConfig(guildId)
@@ -62,7 +64,7 @@ src/
 
 All scoped — grep one to isolate a subsystem:
 
-`[preview]` · `[threads-meta]` · `[ai]` · `[group-context]` · `[probe]` · `[permissions]` · `[mention]` · `[commands]`
+`[preview]` · `[threads-meta]` · `[ai]` · `[group-context]` · `[probe]` · `[permissions]` · `[mention]` · `[commands]` · `[delete]`
 
 ## Smoke tests
 

--- a/.claude/rules/routing.md
+++ b/.claude/rules/routing.md
@@ -81,3 +81,17 @@ Users can suppress the bot by including `nopreview`, `previewignore`, or `fxigno
 - **`inFlightReplies` Set**: prevents duplicate processing if `messageCreate` fires twice (Discord gateway reconnect). Two key formats:
   - URL preview path: `msgId:urls.join("|")`
   - Mention path: `mention:msgId`
+
+## Deleting 西寶's messages (🗑️ reaction)
+
+Handler: [src/reaction-delete.js](../../src/reaction-delete.js), wired as `messageReactionAdd` in [src/index.js](../../src/index.js). For the "傳錯連結想清掉誤發預覽" case — react 🗑️ on the bot's message and it deletes that message.
+
+- **Scope**: any message authored by 西寶 (preview, AI reply, fortune, recap…), never anyone else's.
+- **Emoji**: 🗑️ only (`U+1F5D1`). `isTrashEmoji` strips the optional `U+FE0F` variation selector so both `🗑` and `🗑️` match; other emoji (❌, 🚮) are ignored.
+- **Authorization** (conservative, to stop griefing):
+  1. The **link poster** — 西寶's preview is a `message.reply`, so `fetchReference()` gives the original author's id with no persistent state. If the reactor is that author → delete.
+  2. A **`ManageMessages` mod** in that channel → delete (cleans up others' / orphaned previews).
+  - Reactions from bots are ignored; a message 西寶 didn't author is never touched.
+- **Gap (by design, no state kept)**: if the poster deletes their *original* message first, the preview orphans and `fetchReference()` can no longer prove authorship — then only a `ManageMessages` mod can 🗑️ it. React on the preview *before* deleting the original, or just let a mod clear it.
+- **Requires**: `GuildMessageReactions` intent + `Partials.Message/Channel/Reaction` (so a 🗑️ on a pre-restart, uncached message still fires the event). Both set in [src/index.js](../../src/index.js).
+- Grep `[delete]`. Authorization matrix asserted by `scripts/routing-smoke.js`; `isTrashEmoji` by `scripts/smoke.js`.

--- a/.claude/rules/scripts.md
+++ b/.claude/rules/scripts.md
@@ -35,6 +35,7 @@ Fastest layer (no I/O, no mocks). Covers everything that takes plain values in a
 | `decodeHtmlEntities` covers named + decimal + hex entities | [og-fallback.js](../../src/og-fallback.js) |
 | `hasUsefulMetadata` / `buildGenericFallbackEmbed` | [og-fallback.js](../../src/og-fallback.js) |
 | `buildFallbackUrl` `redd.it` / `old.reddit.com` route to `rxddit` (regression) | [url-routing.js](../../src/url-routing.js) |
+| `isTrashEmoji` matches 🗑️ with/without the FE0F variation selector | [reaction-delete.js](../../src/reaction-delete.js) |
 
 **When to run**: every refactor touching URL handling, persona/template wiring, tier lookup, or group-context formatting. Cheap enough to run on every save.
 
@@ -52,8 +53,9 @@ Branches covered:
 - **Instagram** — post (primary fixer + `fallbackContent` + `embedFallback` + `recoverUrls`) / story with display-name probe failure / story with display-name probe success.
 - **Bilibili** — API success → custom embed (no URL) / API failure → vxbilibili URL with `recoverUrls`.
 - **Preview dispatcher** ([preview.js](../../src/preview.js)) — twitter / **redd.it short** / pixiv / bluesky / facebook all carry `recoverUrls` + `sourceUrl`; multi-URL parallel preserves order.
+- **Reaction delete** ([reaction-delete.js](../../src/reaction-delete.js)) — `handleReactionDelete` authorization matrix with mocked Discord objects (fetchReference / member fetch / permissionsFor): link poster deletes / random user can't / `ManageMessages` mod can / never deletes a non-西寶 message / ignores non-🗑️ / ignores bot reactors. Lives here (not pure smoke) because the auth path needs async Discord I/O.
 
-**When to run**: any reorder of the `if` ladder in `buildThreadsPayload`, any change to `buildPreviewPayloads` dispatch order, any new branch in a platform builder.
+**When to run**: any reorder of the `if` ladder in `buildThreadsPayload`, any change to `buildPreviewPayloads` dispatch order, any new branch in a platform builder, or any change to `reaction-delete.js` authorization.
 
 ## scripts/smoke-ai-circuit.js — AI chain + circuit breaker
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ CommonJS modules under `src/`. Entry point [src/index.js](src/index.js) is just 
 - **Hardcoded mention responses**: `抽籤`/`運勢` → weighted fortune draw; `道歉` → fixed apology string. Never routed to AI. See [persona.md](.claude/rules/persona.md).
 - **Ignore markers**: `nopreview`, `previewignore`, `fxignore` anywhere in a message suppresses the bot.
 - **Dedup window**: 60 s per channel+URL (`DEDUPE_WINDOW_MS`).
+- **刪除西寶的訊息**：在西寶發的**任何**訊息上按 🗑️ 反應 → 貼連結的本人（用 reply reference 認出，不需額外狀態）或有 `ManageMessages` 的管理員可刪掉那則（清掉傳錯連結的誤發預覽）。只動西寶自己的訊息。需 `GuildMessageReactions` intent + Message/Channel/Reaction partials（皆已設於 [src/index.js](src/index.js)）。實作 [src/reaction-delete.js](src/reaction-delete.js)，grep `[delete]`。
 
 ## Workflow
 

--- a/scripts/routing-smoke.js
+++ b/scripts/routing-smoke.js
@@ -45,6 +45,7 @@ const { buildBahamutPayload } = require("../src/platforms/bahamut");
 const { buildPttPayload } = require("../src/platforms/ptt");
 const { buildBilibiliPayload } = require("../src/platforms/bilibili");
 const { buildPreviewPayloads } = require("../src/preview");
+const { handleReactionDelete } = require("../src/reaction-delete");
 
 // === TEST RUNNER ===
 let pass = 0;
@@ -563,6 +564,77 @@ const THREADS_URL = "https://www.threads.net/@a/post/1";
     assert.ok(out[0].content?.includes("fxtwitter"));
     assert.equal(Array.isArray(out[1].embeds), true, "threads should be embed");
     assert.ok(out[2].content?.includes("bskx"));
+  });
+
+  // === REACTION DELETE (reaction-delete.js) ===
+  // handleReactionDelete needs live Discord objects (fetchReference, member
+  // fetch, permissionsFor) that pure smoke can't reach — mock them here and
+  // assert the authorization matrix: only 西寶's OWN message, only by the
+  // link's poster (via reply reference) or a ManageMessages mod, only on 🗑️.
+  console.log("handleReactionDelete — authorization matrix");
+
+  const DELETE_CLIENT = { user: { id: "BOT" } };
+
+  function makeTrashReaction({
+    emojiName = "🗑️",
+    authorId = "BOT", // author of the reacted message (BOT = 西寶's own)
+    origAuthorId = "POSTER", // author of the original message the preview replied to
+    hasReference = true,
+    canManage = false,
+  } = {}) {
+    const state = { deleted: false };
+    const message = {
+      partial: false,
+      id: "MSG",
+      author: { id: authorId },
+      reference: hasReference ? { messageId: "ORIG" } : null,
+      fetchReference: async () => ({ author: { id: origAuthorId } }),
+      guild: {
+        name: "G",
+        members: { cache: new Map(), fetch: async () => ({ id: "m" }) },
+      },
+      channel: { name: "c", permissionsFor: () => ({ has: () => canManage }) },
+      delete: async () => {
+        state.deleted = true;
+      },
+    };
+    return { reaction: { partial: false, emoji: { name: emojiName }, message }, state };
+  }
+
+  await it("link poster's 🗑️ deletes 西寶's own message", async () => {
+    const { reaction, state } = makeTrashReaction({ origAuthorId: "POSTER" });
+    await handleReactionDelete(reaction, { id: "POSTER", bot: false }, DELETE_CLIENT);
+    assert.equal(state.deleted, true);
+  });
+
+  await it("random user without ManageMessages cannot delete", async () => {
+    const { reaction, state } = makeTrashReaction({ origAuthorId: "POSTER", canManage: false });
+    await handleReactionDelete(reaction, { id: "RANDO", bot: false }, DELETE_CLIENT);
+    assert.equal(state.deleted, false);
+  });
+
+  await it("ManageMessages mod can delete even if not the poster", async () => {
+    const { reaction, state } = makeTrashReaction({ origAuthorId: "POSTER", canManage: true });
+    await handleReactionDelete(reaction, { id: "MOD", bot: false }, DELETE_CLIENT);
+    assert.equal(state.deleted, true);
+  });
+
+  await it("never deletes a message 西寶 did not author", async () => {
+    const { reaction, state } = makeTrashReaction({ authorId: "HUMAN", origAuthorId: "POSTER" });
+    await handleReactionDelete(reaction, { id: "POSTER", bot: false }, DELETE_CLIENT);
+    assert.equal(state.deleted, false);
+  });
+
+  await it("ignores non-🗑️ reactions", async () => {
+    const { reaction, state } = makeTrashReaction({ emojiName: "❌", origAuthorId: "POSTER" });
+    await handleReactionDelete(reaction, { id: "POSTER", bot: false }, DELETE_CLIENT);
+    assert.equal(state.deleted, false);
+  });
+
+  await it("ignores reactions from bots", async () => {
+    const { reaction, state } = makeTrashReaction({ origAuthorId: "POSTER" });
+    await handleReactionDelete(reaction, { id: "POSTER", bot: true }, DELETE_CLIENT);
+    assert.equal(state.deleted, false);
   });
 
   console.log("");

--- a/scripts/smoke.js
+++ b/scripts/smoke.js
@@ -71,6 +71,7 @@ const {
 
 const { buildPermissionDebugMessage } = require("../src/commands");
 const { getMissingChannelPermissions } = require("../src/discord-io");
+const { isTrashEmoji } = require("../src/reaction-delete");
 const {
   STORY_MODES,
   localDateKey,
@@ -1830,6 +1831,19 @@ it("buildTargetContextBlock: non-imitation = profile only, samples withheld", ()
   assert.match(block, /被提到的人/);
   assert.doesNotMatch(block, /不好！不好！/);
   assert.equal(buildTargetContextBlock([], { imitation: true }), "");
+});
+
+console.log("reaction-delete.isTrashEmoji");
+it("matches 🗑️ with and without the FE0F variation selector", () => {
+  assert.equal(isTrashEmoji("\u{1F5D1}\uFE0F"), true); // 🗑️
+  assert.equal(isTrashEmoji("\u{1F5D1}"), true); // 🗑
+});
+it("rejects other emoji and non-strings", () => {
+  assert.equal(isTrashEmoji("❌"), false);
+  assert.equal(isTrashEmoji("🚮"), false); // the litter-bin symbol, not the can
+  assert.equal(isTrashEmoji("x"), false);
+  assert.equal(isTrashEmoji(null), false);
+  assert.equal(isTrashEmoji(undefined), false);
 });
 
 console.log("");

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 require("dotenv").config();
 
-const { Client, GatewayIntentBits, MessageFlags } = require("discord.js");
+const { Client, GatewayIntentBits, MessageFlags, Partials } = require("discord.js");
 
 const { DISCORD_TOKEN, AI_TIMEOUT_MS } = require("./config");
 const { shouldIgnoreMessage, extractSupportedUrls } = require("./url-routing");
@@ -18,6 +18,7 @@ const {
   checkAndHandleEmptyEmbeds,
 } = require("./discord-io");
 const { isMentioningBot, handleMention } = require("./mention");
+const { handleReactionDelete } = require("./reaction-delete");
 const { ensureApplicationCommands, handleInteraction } = require("./commands");
 const { AI_PROVIDER_CHAIN } = require("./ai/chain");
 const { startMemorySweepTimer, stopMemorySweepTimer } = require("./ai/memory");
@@ -45,6 +46,12 @@ const client = new Client({
     GatewayIntentBits.MessageContent,
     GatewayIntentBits.GuildMessageReactions,
   ],
+  // A 🗑️ reaction on one of 西寶's own messages requests its deletion. The
+  // target preview is usually recent (a just-sent wrong-link reply), but a
+  // reaction on a message sent before the last restart arrives as a partial —
+  // these partials let messageReactionAdd fire for uncached messages so the
+  // handler can fetch + act on them instead of silently dropping the event.
+  partials: [Partials.Message, Partials.Channel, Partials.Reaction],
 });
 
 client.once("clientReady", async () => {
@@ -102,6 +109,17 @@ client.on("interactionCreate", async (interaction) => {
         `[commands] failed to send error reply: ${replyErr?.message || replyErr}`,
       );
     }
+  }
+});
+
+client.on("messageReactionAdd", async (reaction, user) => {
+  // Symmetric with the handlers above: a throw inside handleReactionDelete
+  // (e.g. a Discord API reject on the delete) must not escape this async
+  // listener and crash the process. Log with context and move on.
+  try {
+    await handleReactionDelete(reaction, user, client);
+  } catch (err) {
+    console.error(`[delete] reaction handler error: ${err?.stack || err}`);
   }
 });
 

--- a/src/reaction-delete.js
+++ b/src/reaction-delete.js
@@ -1,0 +1,89 @@
+const { PermissionsBitField } = require("discord.js");
+const { describeMessageLocation } = require("./discord-io");
+
+// 在西寶自己發的訊息上按 🗑️ 反應即可請它刪掉那則（連結傳錯時清掉誤發的預覽）。
+// U+1F5D1 是垃圾桶本體；Discord 可能帶或不帶 U+FE0F variation selector，兩種
+// 都要接受，所以比較前先去掉 FE0F。
+const TRASH_CODEPOINT = "\u{1F5D1}";
+
+function isTrashEmoji(name) {
+  if (typeof name !== "string") return false;
+  return name.replace(/\uFE0F/g, "") === TRASH_CODEPOINT;
+}
+
+// 誰貼的連結：西寶的預覽是對原訊息的 reply，reference 指回原訊息，所以不必額外
+// 維護狀態就能認出貼文者。原訊息已被刪 / 非 reply（REPLY_MODE=send）→ 回 null，
+// 改由下面的 ManageMessages 授權把關。
+async function getTriggerAuthorId(botMessage) {
+  if (!botMessage.reference?.messageId) return null;
+  if (typeof botMessage.fetchReference !== "function") return null;
+  try {
+    const original = await botMessage.fetchReference();
+    return original.author?.id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// 允許刪除的條件（預設保守，避免路人亂刪）：
+//   1. 貼連結的本人（用 reply reference 認出）
+//   2. 該頻道有「管理訊息」權限的管理員（清理誤發／別人觸發的預覽）
+async function isAuthorizedToDelete(botMessage, user) {
+  const triggerAuthorId = await getTriggerAuthorId(botMessage);
+  if (triggerAuthorId && triggerAuthorId === user.id) return true;
+
+  const guild = botMessage.guild;
+  if (!guild) return false;
+  let member;
+  try {
+    member =
+      guild.members.cache.get(user.id) || (await guild.members.fetch(user.id));
+  } catch {
+    return false;
+  }
+  const perms = botMessage.channel?.permissionsFor(member);
+  return Boolean(perms?.has(PermissionsBitField.Flags.ManageMessages));
+}
+
+async function handleReactionDelete(reaction, user, client) {
+  // 忽略任何機器人（含西寶自己，避免未來若預貼 🗑️ 提示時自我刪除）的反應。
+  if (!user || user.bot || !client?.user) return;
+
+  // emoji 身分在 partial 反應上也拿得到，所以先用它過濾——絕大多數反應都不是
+  // 🗑️，這樣它們就不會白白觸發一次 fetch。
+  if (!isTrashEmoji(reaction.emoji?.name)) return;
+
+  // 訊息可能是 partial：西寶重啟前送出、或已從快取移除的訊息，其反應事件只帶
+  // 精簡的訊息物件，得先補齊才能讀 author / reference。
+  let message = reaction.message;
+  if (message.partial) {
+    try {
+      message = await message.fetch();
+    } catch (error) {
+      console.warn(`[delete] message fetch failed: ${error.message}`);
+      return;
+    }
+  }
+
+  // 只刪西寶自己發的訊息，絕不動別人的。
+  if (message.author?.id !== client.user.id) return;
+
+  if (!(await isAuthorizedToDelete(message, user))) return;
+
+  try {
+    await message.delete();
+    console.log(
+      `[delete] removed message id=${message.id} by=${user.id} ${describeMessageLocation(message)}`,
+    );
+  } catch (error) {
+    console.warn(`[delete] delete failed id=${message.id}: ${error.message}`);
+  }
+}
+
+module.exports = {
+  TRASH_CODEPOINT,
+  isTrashEmoji,
+  getTriggerAuthorId,
+  isAuthorizedToDelete,
+  handleReactionDelete,
+};


### PR DESCRIPTION
🗑️ reaction on any 西寶-authored message deletes it — authorized by the original link poster (via reply reference) or a ManageMessages mod. Docs + smoke assertions included (see .claude/rules/routing.md section).

Tests: npm test 40 passed, 0 failed (local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)