### PR TITLE
feat: emoji 表標記 新/動態 + GuildExpressions intent + 好色 emoji 改看場合

### DIFF
--- a/scripts/smoke.js
+++ b/scripts/smoke.js
@@ -1155,6 +1155,40 @@ it("buildEmojiPromptBlock examples only use available emoji names", () => {
   assert.doesNotMatch(block, /:Ha_seal:/);
   assert.doesNotMatch(block, /:555_dog:/);
 });
+// Build a snowflake id whose embedded timestamp is `ms` since Unix epoch, so the
+// "new" window can be exercised relative to the current wall clock (no fixed id
+// that would rot as real time passes).
+const DISCORD_EPOCH_TEST = 1420070400000;
+const snowflakeForMs = (ms) => String(BigInt(ms - DISCORD_EPOCH_TEST) << 22n);
+it("buildEmojiPromptBlock tags recent + animated emoji and lists new ones first", () => {
+  const map = new Map([
+    ["Good_shark", { id: snowflakeForMs(Date.parse("2020-01-01T00:00:00Z")), animated: false }],
+    ["Waku_fresh", { id: snowflakeForMs(Date.now()), animated: true }],
+  ]);
+  const block = buildEmojiPromptBlock(map);
+  // recent + animated → both tags
+  assert.match(block, /:Waku_fresh:【新】（動態） /);
+  // old one is neither new nor animated
+  assert.doesNotMatch(block, /:Good_shark:【新】/);
+  assert.doesNotMatch(block, /:Good_shark:（動態）/);
+  // new emoji is listed before the old one
+  assert.ok(block.indexOf("Waku_fresh") < block.indexOf("Good_shark"));
+});
+it("buildEmojiPromptBlock surfaces a recent emoji even with no hint", () => {
+  const map = new Map([
+    ["zzq_novelname", { id: snowflakeForMs(Date.now()), animated: false }],
+  ]);
+  const block = buildEmojiPromptBlock(map);
+  // no derivable emotion, but new → still shown, tagged 【新】, with a neutral note
+  assert.match(block, /:zzq_novelname:【新】 /);
+  assert.match(block, /新的，還沒固定用法/);
+});
+it("buildEmojiPromptBlock keeps a context gate on suggestive emoji", () => {
+  const map = new Map([["Pepe_OK", { id: "1", animated: false }]]);
+  const block = buildEmojiPromptBlock(map);
+  // style fix: 好色/曖昧 emoji stay available but are time-gated, not banned
+  assert.match(block, /看場合/);
+});
 
 // --- user-profile-store ---
 const profileStore = require("../src/user-profile-store");

--- a/src/ai/emoji-resolver.js
+++ b/src/ai/emoji-resolver.js
@@ -285,26 +285,65 @@ function resolveCustomEmojis(text, emojiMap) {
     .trim();
 }
 
+// Custom emoji ids are Discord snowflakes: the high 42 bits are a millisecond
+// timestamp, so a larger id means a more recently created emoji. This lets us
+// flag "最近新增" emoji straight from the id — no extra bookkeeping, no gateway
+// event needed. Kept dependency-free (no discord.js import) so the module stays
+// unit-testable in isolation.
+const DISCORD_EPOCH = 1420070400000;
+const NEW_EMOJI_WINDOW_MS = 30 * 24 * 60 * 60 * 1000; // 30 天內建立的算「新」
+
+function emojiCreatedAt(id) {
+  try {
+    return Number(BigInt(id) >> 22n) + DISCORD_EPOCH;
+  } catch {
+    return 0;
+  }
+}
+
 // The emoji table is stable for a whole bot session (the guild emoji cache
 // rarely changes), but generateAIReply rebuilds the system prompt on every
-// call. Memoize on the set of emoji names so we don't re-walk the map + rebuild
-// the (large) string each reply. Cache key is the sorted name list.
+// call. Memoize on the sorted name list PLUS the current "new" set so we don't
+// re-walk the map + rebuild the (large) string each reply, yet still refresh
+// when an emoji ages out of the new-window or a fresh one is added.
 let _promptCache = { sig: null, block: "" };
 
 function buildEmojiPromptBlock(emojiMap) {
   if (!emojiMap || emojiMap.size === 0) return "";
 
   const names = [...emojiMap.keys()].sort();
-  const sig = names.join(",");
+
+  // "New" = created within NEW_EMOJI_WINDOW_MS (derived from the snowflake id).
+  // Folded into the memo signature so the block rebuilds when the new-set drifts,
+  // not only when the name set changes.
+  const newCutoff = Date.now() - NEW_EMOJI_WINDOW_MS;
+  const newSet = new Set(
+    names.filter((name) => emojiCreatedAt(emojiMap.get(name)?.id) >= newCutoff),
+  );
+  const sig = `${names.join(",")}|new:${[...newSet].join(",")}`;
   if (_promptCache.sig === sig) return _promptCache.block;
 
-  // One row per emoji we can confidently describe (exact hint or prefix). Emoji
-  // with no derivable emotion are skipped — they're noise the model would misuse.
-  const rows = [];
-  for (const name of names) {
+  // One row per emoji. The tags are metadata for the model, not part of the token:
+  //   【新】  — created within the new-window; these are listed FIRST so 西寶 can
+  //            honour "用新的貼圖" instead of scanning the whole table and grabbing
+  //            whatever stands out (which is how it kept landing on the spicy ones).
+  //   （動態）— animated emoji, so it can honour "用動態的".
+  // Emoji with no derivable emotion are normally skipped (noise the model would
+  // misuse) — EXCEPT new ones, which we surface with a neutral note so a freshly
+  // added emoji with a novel name isn't invisible exactly when someone asks 西寶
+  // to try it.
+  const makeRow = (name) => {
+    const entry = emojiMap.get(name);
+    const isNew = newSet.has(name);
     const emotion = emotionForName(name);
-    if (emotion) rows.push(`:${name}: ${emotion}`);
-  }
+    if (!emotion && !isNew) return null;
+    const tags = `${isNew ? "【新】" : ""}${entry?.animated ? "（動態）" : ""}`;
+    return `:${name}:${tags} ${emotion || "新的，還沒固定用法，看情境自由發揮"}`;
+  };
+
+  // New emoji first; each group keeps alphabetical order (names is pre-sorted).
+  const ordered = [...newSet, ...names.filter((name) => !newSet.has(name))];
+  const rows = ordered.map(makeRow).filter(Boolean);
 
   if (rows.length === 0) {
     _promptCache = { sig, block: "" };
@@ -329,10 +368,10 @@ function buildEmojiPromptBlock(emojiMap) {
   const lines = [
     "## 你超愛用的群組自訂 emoji（用 :name: 格式打出來，系統會自動轉成圖片）",
     "這些是這個群的梗圖 emoji，你平常聊天會自然夾進句子表達情緒——情緒一上來（害羞、驚訝、無言、開心、哭哭、吐槽）就從下表挑一個丟進句子，不要客氣。",
-    "查表用——每項是「:名字: 用途/情緒」：",
+    "查表用——每項是「:名字:【新】（動態） 用途/情緒」。標【新】的是群裡最近才加的，有人說「用新的貼圖／新的 emoji」時就從標【新】的裡面挑；標（動態）的是動態 emoji：",
     rows.join("　｜　"),
-    `範例（照這格式把 :name: 寫進句子裡，只能使用上表出現過的名字）：${examples.join("")}`,
-    "**只能用上表這些群組自訂 :name: emoji，絕對不要用 Unicode／系統 emoji（😳💦😣😅 這種一律禁止）**。表裡找不到貼切的就用括號動作或語氣詞，別拿系統 emoji 頂替。每則挑 1 個最貼切的就好，別硬塞一堆。",
+    `範例（照這格式把 :name: 寫進句子，標註的【新】（動態）是給你看的、打字時不要打出來，只能用上表出現過的名字）：${examples.join("")}`,
+    "**只能用上表這些群組自訂 :name: emoji，絕對不要用 Unicode／系統 emoji（😳💦😣😅 這種一律禁止）**。表裡找不到貼切的就用括號動作或語氣詞，別拿系統 emoji 頂替。每則挑 1 個最貼切的就好，別硬塞一堆。帶性暗示、黃或身體梗那類 emoji 要看場合——只在對方也在開黃腔、氣氛曖昧時才用；一般聊天、人家在問你問題或聊正經事（像在問貼圖、功能）時丟那種會很出戲，收斂點、讀空氣。",
   ];
 
   const block = `\n\n${lines.join("\n")}`;

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,12 @@ const client = new Client({
     GatewayIntentBits.GuildMessages,
     GatewayIntentBits.MessageContent,
     GatewayIntentBits.GuildMessageReactions,
+    // Without this, guild.emojis.cache is only populated at GUILD_CREATE
+    // (startup): an emoji added while the bot is running stays invisible to
+    // 西寶's emoji prompt table until the next restart. GuildExpressions
+    // delivers GuildEmojisUpdate so the cache tracks live adds/removals.
+    // Non-privileged — no Dev Portal toggle needed.
+    GatewayIntentBits.GuildExpressions,
   ],
   // A 🗑️ reaction on one of 西寶's own messages requests its deletion. The
   // target preview is usually recent (a just-sent wrong-link reply), but a


### PR DESCRIPTION
## 背景

群友叫 @西寶「群裡新增了貼圖，用用看」「有 2 個新的動態 emoji 你用用看」，結果西寶：

1. **用不到新貼圖** — 一直亂猜、還反問「新的動態 emoji 是哪兩個？」
2. **一直撞到 `:Ecchi:` / `:z_garden_eel:`** → 被吐槽「這到底什麼色情 AI」

根因都在 `buildEmojiPromptBlock`：它把整張 emoji 表塞進 system prompt，但**每列只有 `:name: 情緒`**——沒有新/舊、沒有動態/靜態欄位，西寶無從分辨；而且被叫「試貼圖」時它掃整張表，最搶眼的就是那些帶「好色/雞雞」註解的。

## 改動

**D — 表格能表達新/動態**（`src/ai/emoji-resolver.js`）
- Discord emoji id 是 snowflake，高 42 bits＝建立毫秒 → **直接從 id 推新舊**，不必額外存資料、不必加 gateway 事件。
- 30 天內建立的標 `【新】`、動態的標 `（動態）`，**新的排最前**——西寶被叫「用新的／用動態的」時有依據可挑。
- 沒有 hint 的新 emoji 也一併 surface（附「新的，還沒固定用法」中性註解），免得剛加的貼圖在別人正要它試用時反而隱形。
- memo 簽章納入 new-set，讓 emoji 過了新窗口時表格會刷新。

**風格 — 好色改「看場合」，不封鎖**
- 依產品判斷：好色 emoji **可以用，只是要在適切時機**，不是拿掉。
- 所以**不設黑名單**（沒動 `EMOJI_BLACKLIST`），改在 prompt 加時機規則：帶性暗示／黃的 emoji 只在對方也在開黃腔時才用；聊正經事、問問題時收斂、讀空氣。
- 一般 emoji 的「不要客氣」保留，**個性邊界不動**。

## 測試

`npm test` 三層全綠（pure 183 / routing / circuit 40），新增 4 案：
- 新+動態同時標記、新的排最前
- 無 hint 的新 emoji 仍 surface
- 舊 emoji 不被誤標
- 好色 emoji 的「看場合」規則存在（回歸防線）

**C — `GuildExpressions` intent**（`src/index.js`，第二個 commit）
- 沒有它時 `guild.emojis.cache` 只在啟動（GUILD_CREATE）灌一次，**執行中新增的 emoji 對西寶隱形到下次重啟**——就是這次「叫西寶用新貼圖、它卻找不到」的硬性成因。
- 加了之後 Discord 即時推 `GuildEmojisUpdate`，discord.js 自動同步快取，**新貼圖即加即用、免重啟**。
- Non-privileged，Dev Portal 免申請。

## 刻意不做

- **A（黑名單）** — 依產品判斷保留好色 emoji，只調時機。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
