### PR TITLE
feat: 每日回顧的熱門訊息附前後文脈絡

### DIFF
--- a/scripts/smoke.js
+++ b/scripts/smoke.js
@@ -1880,6 +1880,114 @@ it("rejects other emoji and non-strings", () => {
   assert.equal(isTrashEmoji(undefined), false);
 });
 
+console.log("daily-recap context");
+const {
+  buildMessagePreview,
+  buildMessageContext,
+  buildRecapStats,
+} = require("../src/daily-recap");
+
+// Minimal discord.js Collection stand-in: size / values / filter / map.
+function recapColl(items) {
+  return {
+    size: items.length,
+    values: () => items[Symbol.iterator](),
+    filter: (fn) => recapColl(items.filter(fn)),
+    map: (fn) => items.map(fn),
+  };
+}
+
+function recapMsg({
+  id,
+  ch = "c1",
+  chName = "閃現",
+  author = "小翔",
+  ts = 0,
+  content = "",
+  reactions = [],
+  stickers = [],
+}) {
+  return {
+    id,
+    channelId: ch,
+    channel: { id: ch, name: chName },
+    author: { id: `id-${author}`, bot: false, username: author },
+    member: { displayName: author },
+    content,
+    createdTimestamp: ts,
+    reactions: {
+      cache: recapColl(
+        reactions.map(([name, count]) => ({ emoji: { id: null, name }, count })),
+      ),
+    },
+    stickers: recapColl(stickers.map((name) => ({ name }))),
+    attachments: recapColl([]),
+  };
+}
+
+it("buildMessagePreview: sticker-only message shows the sticker name", () => {
+  const m = recapMsg({ id: "s1", stickers: ["起床重睡"] });
+  assert.equal(buildMessagePreview(m), "（貼圖：起床重睡）");
+});
+
+it("buildMessagePreview: long content truncated at 60 chars", () => {
+  const m = recapMsg({ id: "s2", content: "字".repeat(80) });
+  assert.equal(buildMessagePreview(m), "字".repeat(60) + "…");
+});
+
+it("buildMessagePreview: no content/sticker/attachment → 嵌入 placeholder", () => {
+  assert.equal(buildMessagePreview(recapMsg({ id: "s3" })), "（嵌入/連結）");
+});
+
+it("buildRecapStats: top-reacted message carries chronological context with the target marked", () => {
+  const msgs = [];
+  for (let i = 1; i <= 8; i++) {
+    msgs.push(
+      recapMsg({
+        id: `m${i}`,
+        ts: i,
+        content: `第${i}句`,
+        author: i % 2 ? "小翔" : "濤濤",
+        reactions: i === 6 ? [["😂", 5]] : [],
+      }),
+    );
+  }
+  // A different channel's message must never leak into c1's context.
+  msgs.push(recapMsg({ id: "x1", ch: "c2", chName: "蘑菇鳥", ts: 5, content: "別的頻道" }));
+
+  const stats = buildRecapStats(msgs);
+  assert.equal(stats.topReacted.length, 1);
+  const ctx = stats.topReacted[0].context;
+  // 4 before (m2..m5) + target (m6) + 2 after (m7, m8) = 7 lines
+  assert.equal(ctx.length, 7);
+  assert.match(ctx[0], /第2句/);
+  assert.match(ctx[4], /第6句/);
+  assert.match(ctx[4], /就是這句拿到反應/);
+  assert.match(ctx[6], /第8句/);
+  assert.ok(ctx.every((l) => !l.includes("別的頻道")));
+  // Only the target line carries the marker.
+  assert.equal(ctx.filter((l) => l.includes("就是這句拿到反應")).length, 1);
+});
+
+it("buildRecapStats: sticker-only reacted message gets sticker-name preview and context", () => {
+  const msgs = [
+    recapMsg({ id: "a1", ts: 1, content: "有人對後面很敏感喔", author: "狗哥" }),
+    recapMsg({ id: "a2", ts: 2, stickers: ["尷尬的Rin"], author: "濤濤", reactions: [["🤣", 4]] }),
+    recapMsg({ id: "a3", ts: 3, content: "D包廂", author: "狗哥" }),
+  ];
+  const stats = buildRecapStats(msgs);
+  const top = stats.topReacted[0];
+  assert.equal(top.preview, "（貼圖：尷尬的Rin）");
+  assert.match(top.context.join("\n"), /有人對後面很敏感喔/);
+  assert.match(top.context.join("\n"), /D包廂/);
+  assert.match(top.context.join("\n"), /貼圖：尷尬的Rin/);
+});
+
+it("buildMessageContext: target missing from pool returns empty (no crash)", () => {
+  const target = recapMsg({ id: "ghost", ts: 9 });
+  assert.deepEqual(buildMessageContext(target, []), []);
+});
+
 console.log("");
 console.log(`Result: ${pass} passed, ${fail} failed`);
 process.exit(fail > 0 ? 1 : 0);

--- a/src/daily-recap.js
+++ b/src/daily-recap.js
@@ -2,9 +2,18 @@
 // builds recap stats for the scheduler's `daily_recap` task type.
 
 const { ChannelType } = require("discord.js");
+const { formatGroupMessage } = require("./ai/group-context");
 
 const MAX_FETCH_PER_CHANNEL = 200;
 const LOOKBACK_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+// Surrounding messages attached to each top-reacted message so the recap
+// model can tell WHAT was funny — a sticker or a one-liner like「好小…」is
+// meaningless without the conversation around it. Pulled from the already
+// fetched 24 h pool, so this costs zero extra Discord API calls.
+const RECAP_CONTEXT_BEFORE = 4;
+const RECAP_CONTEXT_AFTER = 2;
+const RECAP_CONTEXT_LINE_MAX = 120;
 
 // ── Fetch ───────────────────────────────────────────────────────────────
 
@@ -78,7 +87,54 @@ async function fetchGuildMessages(guild, lookbackMs = LOOKBACK_MS) {
 
 // ── Stats ───────────────────────────────────────────────────────────────
 
+// What the reacted message itself "said" — sticker names and attachment kind
+// beat the old opaque「（圖片/貼圖/嵌入）」placeholder.
+function buildMessagePreview(m) {
+  if (m.content) {
+    return m.content.length > 60 ? m.content.slice(0, 60) + "…" : m.content;
+  }
+  if (m.stickers?.size > 0) {
+    const names = m.stickers.map((s) => s.name).join("、");
+    return `（貼圖：${names}）`;
+  }
+  if (m.attachments?.size > 0) return "（圖片/附件）";
+  return "（嵌入/連結）";
+}
+
+// Surrounding messages from the same channel, chronological, with the target
+// marked so the model knows which line got the reactions.
+function buildMessageContext(target, channelMessagesAsc) {
+  const idx = channelMessagesAsc.findIndex((m) => m.id === target.id);
+  if (idx === -1) return [];
+  const start = Math.max(0, idx - RECAP_CONTEXT_BEFORE);
+  const end = Math.min(channelMessagesAsc.length, idx + RECAP_CONTEXT_AFTER + 1);
+
+  const lines = [];
+  for (let i = start; i < end; i++) {
+    const m = channelMessagesAsc[i];
+    let line = formatGroupMessage(m);
+    if (!line) continue;
+    if (line.length > RECAP_CONTEXT_LINE_MAX) {
+      line = line.slice(0, RECAP_CONTEXT_LINE_MAX) + "…";
+    }
+    if (i === idx) line += "　← 就是這句拿到反應";
+    lines.push(line);
+  }
+  return lines;
+}
+
 function buildRecapStats(messages) {
+  // Per-channel chronological index for context lookup.
+  const byChannel = new Map();
+  for (const m of messages) {
+    const chId = m.channelId ?? m.channel?.id;
+    if (!chId) continue;
+    if (!byChannel.has(chId)) byChannel.set(chId, []);
+    byChannel.get(chId).push(m);
+  }
+  for (const list of byChannel.values()) {
+    list.sort((a, b) => (a.createdTimestamp ?? 0) - (b.createdTimestamp ?? 0));
+  }
   const nonBotMessages = messages.filter((m) => !m.author?.bot);
 
   // Per-author message count
@@ -124,23 +180,26 @@ function buildRecapStats(messages) {
         m.author?.username ||
         "未知";
       const channelName = m.channel?.name || "未知頻道";
-      const preview = m.content
-        ? m.content.length > 60
-          ? m.content.slice(0, 60) + "…"
-          : m.content
-        : "（圖片/貼圖/嵌入）";
       return {
         authorName,
         channelName,
-        preview,
+        preview: buildMessagePreview(m),
         totalReactions,
         score,
         reactionStr: reactionList.join(" "),
         isBot: m.author?.bot ?? false,
+        _msg: m,
       };
     })
     .sort((a, b) => b.score - a.score)
-    .slice(0, 8);
+    .slice(0, 8)
+    .map(({ _msg, ...entry }) => ({
+      ...entry,
+      context: buildMessageContext(
+        _msg,
+        byChannel.get(_msg.channelId ?? _msg.channel?.id) || [],
+      ),
+    }));
 
   const topAuthors = [...authorMap.values()]
     .sort((a, b) => b.count - a.count)
@@ -174,6 +233,8 @@ function buildRecapPrompt(stats, channelStats, guildName) {
       "內容要求：",
       "- 先聊聊今天整體的熱鬧程度，哪個頻道最活躍、誰講最多話。",
       "- 然後分享幾個最受歡迎的訊息（有表情反應的），每個都聊一兩句你的感想。",
+      "- 每則熱門訊息下面附有「前後文」，先讀懂當時在聊什麼再寫感想——特別是貼圖或短句，光看那一句猜不出笑點。前後文只是給你理解用的，不要照抄、不要逐條複述。",
+      "- 如果看了前後文還是不確定在聊什麼，就老實承認沒看懂、表達好奇就好，不要瞎編劇情。",
       "- 結尾可以有個簡短的感想或期待。）",
     ].join("\n"),
     "",
@@ -202,6 +263,12 @@ function buildRecapPrompt(stats, channelStats, guildName) {
       lines.push(
         `${i + 1}. ${msg.authorName} 在 #${msg.channelName}：「${msg.preview}」— ${msg.reactionStr}（共 ${msg.totalReactions} 個反應）`,
       );
+      if (msg.context?.length > 0) {
+        lines.push("   前後文：");
+        for (const ctxLine of msg.context) {
+          lines.push(`   ${ctxLine}`);
+        }
+      }
     }
   } else {
     lines.push("今天沒有人按任何表情反應。");
@@ -213,8 +280,12 @@ function buildRecapPrompt(stats, channelStats, guildName) {
 module.exports = {
   MAX_FETCH_PER_CHANNEL,
   LOOKBACK_MS,
+  RECAP_CONTEXT_BEFORE,
+  RECAP_CONTEXT_AFTER,
   fetchChannelMessages,
   fetchGuildMessages,
+  buildMessagePreview,
+  buildMessageContext,
   buildRecapStats,
   buildRecapPrompt,
 };


### PR DESCRIPTION
## 問題

每日回顧的 prompt 只給每則熱門訊息**自己的** 60 字預覽，貼圖/圖片訊息更是只剩「（圖片/貼圖/嵌入）」佔位符——西寶看不到當時的對話，只能瞎猜（使用者回報：表情符號拿讚時搞不清楚發文內容）。

## 改法

`fetchGuildMessages` 本來就把 24 小時內所有訊息抓在記憶體裡，所以**零額外 Discord API call**：

- 每則 top-reacted 訊息從同頻道訊息池撈前 4 句＋後 2 句，用現成的 `formatGroupMessage`（會顯示貼圖名稱、附件標記）排成縮排的「前後文」塊，目標句標記 `← 就是這句拿到反應`
- 預覽佔位符升級：貼圖訊息顯示 `（貼圖：名稱）`，其餘分「（圖片/附件）」「（嵌入/連結）」
- prompt 新增兩條內容要求：先讀懂前後文再寫感想、看不懂就老實承認不要瞎編
- 每行前後文截 120 字，8 則 × 最多 7 行，token 增量有上限

## 測試

- `npm test` 全過（smoke 189 passed）
- smoke.js 新增 daily-recap 六個 case（此前 recap 零測試覆蓋）：貼圖預覽、60 字截斷、前後文時序＋標記唯一性、跨頻道不滲漏、目標不在池中不炸

🤖 Generated with [Claude Code](https://claude.com/claude-code)