### PR TITLE
fix: drop trailing slashes in .gitignore so worktree symlinks are ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
-node_modules/
+# No trailing slash on node_modules/data: `x/` only matches a real DIRECTORY,
+# so a worktree's `node_modules -> main/node_modules` SYMLINK slips past it —
+# `git add -A` then commits the symlink, and checking that branch out in the
+# main tree REPLACES the real (ignored = expendable) dirs with self-pointing
+# links, deleting their contents. Cost us data/ once (2026-07-05).
+node_modules
 .env
 .env.*
 !.env.example
@@ -9,5 +14,5 @@ stop-bot.command
 bot.log
 bot.log.*
 *.log
-data/
+data
 


### PR DESCRIPTION
## 背景

`main` 的 `.gitignore` 仍用帶斜線 pattern（`node_modules/`、`data/`）。trailing-slash pattern 只匹配真目錄、**不匹配 symlink**：worktree 工作流裡 `.env`/`node_modules`/`data` 是指回主 checkout 的 symlink，`git add -A` 會把 symlink 提交進分支；之後在主樹 checkout 該分支，git 就用自環 symlink 蓋掉真目錄（ignored = expendable），**目錄內容全滅**——2026-07-05 的 `data/` 事故即此根因。

修復 commit 60504c3 只存在於 deploy/* 分支，從未回到 main。本 PR 把其中 `.gitignore` 的部分移植回來（main 從未 track 那些 symlink，所以 60504c3 的 untrack 部分在此不適用）。

## 變更

- `node_modules/` → `node_modules`、`data/` → `data`（無斜線 pattern 同時匹配目錄與 symlink）
- 加上說明註解，記錄為什麼不能加回斜線

## 驗證

- `git check-ignore -v .env node_modules` 在掛了 symlink 的 worktree 中命中新 pattern，`git status` 乾淨
- `npm test`：40 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)