### PR TITLE
feat: evidence-based long-term memory（messageId 去重＋來源權重＋證據門檻＋backlog sweep）

### DIFF
--- a/docs/ai-providers.md
+++ b/docs/ai-providers.md
@@ -87,6 +87,18 @@ Avoids silent channels lingering in RAM forever:
 
 No persistence — restart clears everything.
 
+## Long-term memory (evidence pipeline)
+
+Per-user profiles in `data/user-profiles.json` ([user-profile-store.js](../src/user-profile-store.js)), built by [observation-extractor.js](../src/ai/observation-extractor.js). Flow: pending interactions → LLM 萃取 observations → LLM consolidation 成人格摘要. Log prefixes: `[observation-extractor]`, `[consolidate]`, `[backlog-sweep]`.
+
+**Two intake paths, one Discord messageId each.** `direct` = the user @ed 西寶 and got an AI reply. `passive` = the user's line sat in the last 3 group-context rows when *someone else* triggered 西寶 (`getPersonalMemoryContextEntries` in chain.js). Dedup is **by messageId only, never by text** — repeating the same sentence across messages can itself be a trait; the same message scooped twice is the only certain duplicate. Backlog is capped at `PENDING_MAX_COUNT` (60, oldest dropped).
+
+**Evidence is code-enforced, not LLM-trusted.** Extraction prompts number every pending row and tag it 【直接互動】/【旁聽片段】; the model must return `evidence: [編號]` per observation. `attachEvidence` resolves those to `{messageId, at, source}` records and caps confidence: no resolvable message → ≤0.3, single message → ≤0.4, passive-only evidence → ≤0.5. Same-text observations extracted in later batches merge and pool evidence (union by messageId), so a trait can *earn* stability over time.
+
+**Stability bar** (`isStableObservation`): ≥3 distinct messageIds, or 2 distinct messageIds ≥6 h apart. Consolidation splits observations into 已達證據門檻 (may be stated in the profile) vs 證據不足 (must be ignored or hedged with 或許/有時 — never asserted). Both personas demand neutral behavioural wording and explicitly ban unsupported praise (靈魂人物/精準/擅長…).
+
+**Backlog sweep** ([profile-sweep.js](../src/ai/profile-sweep.js)). Extraction normally fires only on the user's own next successful AI reply — passively-scooped users would otherwise accumulate forever (the 30-筆 小翔 case, 2026-07-19). A timer (start +5 min, then every `PROFILE_SWEEP_INTERVAL_MS`, default 1 h, `0` disables) drains users whose backlog ≥ `EXTRACT_MIN_COUNT`: max 3 users per pass, skips anyone whose last pending row is <10 min old (mid-conversation), oldest `lastExtractedAt` first. Uses the same per-guild provider chain as live replies.
+
 ## Gemini billing trap
 
 If a Google Cloud project has a billing account attached (even $300 free trial), the Gemini API free tier becomes `limit: 0`.

--- a/docs/env.md
+++ b/docs/env.md
@@ -42,6 +42,7 @@
 | `AI_PERSONA` | built-in 西寶 persona | System instruction template — override to reshape personality. Placeholders `{SENTENCE_MIN}` / `{SENTENCE_MAX}` are replaced per AI plan |
 | `AI_MEMORY_TTL_MS` | `1800000` | Inactivity before channel memory is evicted (30 min) |
 | `AI_LONG_TERM_MEMORY_ENABLED` | `true` | Enables user/guild long-term observation extraction and profile prompt blocks |
+| `PROFILE_SWEEP_INTERVAL_MS` | `3600000` | Backlog-sweep cadence for passively-collected pending interactions (1 h). `0` disables the sweep |
 | `EMOJI_TRUSTED_GUILD_IDS` | — | Comma-separated guild IDs whose custom emoji may be shared when the current guild is also trusted |
 
 **Reply length, memory depth, and DeepSeek model selection are now per-guild AI plan settings** (see [persona.md](persona.md) `/ai-tier` section), not env vars. The legacy `AI_MAX_REPLY_CHARS` / `AI_MEMORY_MAX_TURNS` env vars are no longer read.

--- a/scripts/smoke.js
+++ b/scripts/smoke.js
@@ -1432,6 +1432,15 @@ const {
   buildGuildExtractionTurns,
   shouldGuildConsolidate,
   buildGuildConsolidationTurns,
+  parseEvidenceIndices,
+  attachEvidence,
+  isStableObservation,
+  describeObservationEvidence,
+  selectBacklogUsers,
+  STABLE_MIN_DISTINCT_MESSAGES,
+  STABLE_TIME_GAP_MS,
+  EXTRACTION_PERSONA,
+  CONSOLIDATION_PERSONA,
   resetForTests: resetExtractorForTests,
 } = require("../src/ai/observation-extractor");
 
@@ -1520,7 +1529,8 @@ it("shouldConsolidate true when total obs chars >= 1200", () => {
   withProfileStore(() => {
     const obs = [];
     for (let i = 0; i < 11; i++) {
-      obs.push({ text: "字".repeat(120), confidence: 0.7 });
+      // Distinct texts — identical texts would merge into one observation.
+      obs.push({ text: `${i}${"字".repeat(119)}`, confidence: 0.7 });
     }
     profileStore.appendObservations("g1", "u1", "x", obs);
     assert.equal(shouldConsolidate("g1", "u1"), true);
@@ -1575,6 +1585,211 @@ it("parseConsolidationResult returns null for garbage", () => {
   assert.equal(parseConsolidationResult("not json"), null);
   assert.equal(parseConsolidationResult(null), null);
   assert.equal(parseConsolidationResult(""), null);
+});
+// --- memory evidence pipeline ---
+console.log("memory evidence");
+it("appendPendingInteraction dedups by messageId, not by text", () => {
+  withProfileStore(() => {
+    // Same message scooped twice → one record.
+    assert.equal(
+      profileStore.appendPendingInteraction("g1", "u1", "x", "同一句", "", { messageId: "m1", source: "passive" }),
+      true,
+    );
+    assert.equal(
+      profileStore.appendPendingInteraction("g1", "u1", "x", "同一句", "", { messageId: "m1", source: "passive" }),
+      false,
+    );
+    // Same TEXT from a different message → kept (repetition can be a trait).
+    assert.equal(
+      profileStore.appendPendingInteraction("g1", "u1", "x", "同一句", "", { messageId: "m2", source: "passive" }),
+      true,
+    );
+    // No messageId → never deduped.
+    profileStore.appendPendingInteraction("g1", "u1", "x", "同一句", "");
+    profileStore.appendPendingInteraction("g1", "u1", "x", "同一句", "");
+    const pending = profileStore.getPendingInteractions("g1", "u1");
+    assert.equal(pending.length, 4);
+  });
+});
+it("appendPendingInteraction records messageId, source, and at", () => {
+  withProfileStore(() => {
+    profileStore.appendPendingInteraction("g1", "u1", "x", "hi", "yo", {
+      messageId: "m9", source: "direct", at: 12345,
+    });
+    profileStore.appendPendingInteraction("g1", "u1", "x", "[x]: line", "", {
+      messageId: "m10", source: "passive",
+    });
+    const [direct, passive] = profileStore.getPendingInteractions("g1", "u1");
+    assert.equal(direct.messageId, "m9");
+    assert.equal(direct.source, "direct");
+    assert.equal(direct.at, 12345);
+    assert.equal(passive.source, "passive");
+    assert.ok(passive.at > 0, "missing at falls back to now");
+    // Unknown source value normalizes to direct.
+    profileStore.appendPendingInteraction("g1", "u1", "x", "a", "b", { source: "weird" });
+    const all = profileStore.getPendingInteractions("g1", "u1");
+    assert.equal(all[2].source, "direct");
+  });
+});
+it("appendPendingInteraction caps backlog at PENDING_MAX_COUNT (drops oldest)", () => {
+  withProfileStore(() => {
+    for (let i = 0; i < profileStore.PENDING_MAX_COUNT + 5; i++) {
+      profileStore.appendPendingInteraction("g1", "u1", "x", `msg${i}`, "", { messageId: `m${i}` });
+    }
+    const pending = profileStore.getPendingInteractions("g1", "u1");
+    assert.equal(pending.length, profileStore.PENDING_MAX_COUNT);
+    assert.equal(pending[0].userText, "msg5", "oldest dropped");
+  });
+});
+it("listPendingBacklog reports users at/above minCount", () => {
+  withProfileStore(() => {
+    profileStore.appendPendingInteraction("g1", "u1", "A", "a", "", { messageId: "m1", at: 100 });
+    profileStore.appendPendingInteraction("g1", "u1", "A", "b", "", { messageId: "m2", at: 200 });
+    profileStore.appendPendingInteraction("g2", "u2", "B", "c", "", { messageId: "m3" });
+    const backlog = profileStore.listPendingBacklog(2);
+    assert.equal(backlog.length, 1);
+    assert.equal(backlog[0].guildId, "g1");
+    assert.equal(backlog[0].userId, "u1");
+    assert.equal(backlog[0].pendingCount, 2);
+    assert.equal(backlog[0].lastPendingAt, 200);
+  });
+});
+it("buildExtractionTurns numbers entries and tags direct vs passive", () => {
+  const turns = buildExtractionTurns([
+    { userText: "你好", assistantText: "嗯…", source: "direct" },
+    { userText: "[某人]: 旁聽的話", assistantText: "", source: "passive" },
+    { userText: "舊直接紀錄", assistantText: "有回覆" },
+    { userText: "[某人]: 舊旁聽紀錄", assistantText: "" },
+  ]);
+  const content = turns[0].content;
+  assert.match(content, /#1【直接互動】/);
+  assert.match(content, /#2【旁聽片段】/);
+  assert.match(content, /#3【直接互動】/, "legacy record with reply = direct");
+  assert.match(content, /#4【旁聽片段】/, "legacy record without reply = passive");
+});
+it("parseEvidenceIndices keeps unique positive ints only", () => {
+  assert.deepEqual(parseEvidenceIndices([1, 3, 3, "2", 0, -1, 1.5, "x"]), [1, 3, 2]);
+  assert.deepEqual(parseEvidenceIndices("nope"), []);
+  assert.deepEqual(parseEvidenceIndices(undefined), []);
+});
+it("parseExtractionResult carries evidence indices through", () => {
+  const obs = parseExtractionResult(
+    '{"observations":[{"text":"常聊棒球","confidence":0.8,"evidence":[1,4]}]}',
+  );
+  assert.deepEqual(obs[0].evidence, [1, 4]);
+  const noEv = parseExtractionResult('{"observations":[{"text":"x","confidence":0.8}]}');
+  assert.deepEqual(noEv[0].evidence, []);
+});
+it("attachEvidence resolves indices to messageIds and caps confidence", () => {
+  const pending = [
+    { userText: "a", assistantText: "r", messageId: "m1", at: 1000, source: "direct" },
+    { userText: "b", assistantText: "", messageId: "m2", at: 2000, source: "passive" },
+    { userText: "c", assistantText: "", messageId: null, source: "passive" },
+    { userText: "d", assistantText: "r", messageId: "m4", at: 4000, source: "direct" },
+    { userText: "e", assistantText: "", messageId: "m5", at: 5000, source: "passive" },
+  ];
+  const [full, single, none, passiveOnly] = attachEvidence(
+    [
+      { text: "三則佐證", confidence: 0.9, evidence: [1, 2, 4] },
+      { text: "單則佐證", confidence: 0.9, evidence: [1] },
+      { text: "無佐證", confidence: 0.9, evidence: [3, 99] },
+      { text: "全旁聽", confidence: 0.9, evidence: [2, 5, 2] },
+    ],
+    pending,
+  );
+  assert.deepEqual(full.evidence.map((e) => e.messageId), ["m1", "m2", "m4"]);
+  assert.equal(full.confidence, 0.9, "well-evidenced keeps confidence");
+  assert.equal(single.confidence, 0.4, "single message capped");
+  assert.equal(none.evidence.length, 0, "null-messageId and out-of-range dropped");
+  assert.equal(none.confidence, 0.3, "no evidence capped hardest");
+  assert.equal(passiveOnly.confidence, 0.5, "passive-only capped");
+});
+it("isStableObservation: 3 distinct messages, or 2 far enough apart", () => {
+  const ev = (messageId, at, source = "direct") => ({ messageId, at, source });
+  assert.equal(
+    isStableObservation({ evidence: [ev("m1", 0), ev("m2", 1), ev("m3", 2)] }),
+    true,
+    `${STABLE_MIN_DISTINCT_MESSAGES} distinct messages`,
+  );
+  assert.equal(
+    isStableObservation({ evidence: [ev("m1", 0), ev("m2", 1000)] }),
+    false,
+    "2 messages in one burst",
+  );
+  assert.equal(
+    isStableObservation({ evidence: [ev("m1", 0), ev("m2", STABLE_TIME_GAP_MS)] }),
+    true,
+    "2 messages across time",
+  );
+  assert.equal(isStableObservation({ evidence: [] }), false);
+  assert.equal(isStableObservation({}), false, "legacy observation without evidence");
+});
+it("appendObservations merges same-text observations and pools evidence", () => {
+  withProfileStore(() => {
+    profileStore.appendObservations("g1", "u1", "x", [
+      { text: "常聊棒球", confidence: 0.4, evidence: [{ messageId: "m1", at: 1, source: "direct" }] },
+    ]);
+    profileStore.appendObservations("g1", "u1", "x", [
+      { text: "常聊棒球", confidence: 0.7, evidence: [{ messageId: "m2", at: 2, source: "passive" }, { messageId: "m1", at: 1, source: "direct" }] },
+    ]);
+    const p = profileStore.getUserProfile("g1", "u1");
+    assert.equal(p.observations.length, 1, "same text merged");
+    assert.deepEqual(
+      p.observations[0].evidence.map((e) => e.messageId),
+      ["m1", "m2"],
+      "evidence unioned by messageId",
+    );
+    assert.equal(p.observations[0].confidence, 0.7, "keeps max confidence");
+  });
+});
+it("buildConsolidationTurns separates stable from under-evidenced observations", () => {
+  const ev = (id, at) => ({ messageId: id, at, source: "direct" });
+  const turns = buildConsolidationTurns({
+    name: "Alice",
+    profile: null,
+    observations: [
+      { text: "常聊棒球", confidence: 0.8, evidence: [ev("m1", 0), ev("m2", 1), ev("m3", 2)] },
+      { text: "問過星座", confidence: 0.6, evidence: [ev("m4", 0)] },
+    ],
+  });
+  const content = turns[0].content;
+  assert.match(content, /已達證據門檻[\s\S]*常聊棒球（信心 0.8，3 則訊息佐證）/);
+  assert.match(content, /證據不足[\s\S]*問過星座（信心 0.6，1 則訊息佐證）/);
+  assert.ok(
+    content.indexOf("常聊棒球") < content.indexOf("證據不足"),
+    "stable section comes first",
+  );
+});
+it("describeObservationEvidence counts distinct messageIds", () => {
+  assert.equal(describeObservationEvidence({}), "無訊息佐證");
+  assert.equal(
+    describeObservationEvidence({ evidence: [{ messageId: "m1" }, { messageId: "m1" }, { messageId: "m2" }] }),
+    "2 則訊息佐證",
+  );
+});
+it("personas demand evidence and ban unsupported praise", () => {
+  assert.match(EXTRACTION_PERSONA, /evidence 必填/);
+  assert.match(EXTRACTION_PERSONA, /旁聽片段/);
+  assert.match(EXTRACTION_PERSONA, /中性/);
+  assert.match(CONSOLIDATION_PERSONA, /靈魂人物/, "praise words named as banned examples");
+  assert.match(CONSOLIDATION_PERSONA, /不可寫成斷言/);
+});
+it("selectBacklogUsers filters busy users, sorts starved-first, caps count", () => {
+  const now = 1_000_000;
+  const idle = 10 * 60 * 1000;
+  const backlog = [
+    { guildId: "g", userId: "busy", lastPendingAt: now - 1000, lastExtractedAt: 0 },
+    { guildId: "g", userId: "recent", lastPendingAt: now - idle, lastExtractedAt: 500 },
+    { guildId: "g", userId: "starved", lastPendingAt: now - idle, lastExtractedAt: 100 },
+    { guildId: "g", userId: "third", lastPendingAt: now - idle, lastExtractedAt: 300 },
+    { guildId: "g", userId: "fourth", lastPendingAt: now - idle, lastExtractedAt: 400 },
+  ];
+  const picked = selectBacklogUsers(backlog, { now, maxUsers: 3, minIdleMs: idle });
+  assert.deepEqual(
+    picked.map((b) => b.userId),
+    ["starved", "third", "fourth"],
+    "mid-conversation user excluded, oldest extraction first, capped at 3",
+  );
 });
 // --- guild-profile-store ---
 const guildStore = require("../src/guild-profile-store");

--- a/src/ai/chain.js
+++ b/src/ai/chain.js
@@ -386,7 +386,11 @@ async function generateAIReply(message, userText) {
       const userId = message.author?.id;
       const runChain = (t, p, m) => runProviderChain(guildChain, t, p, m);
       if (guildId && userId) {
-        appendPendingInteraction(guildId, userId, displayName, userText, capped);
+        appendPendingInteraction(guildId, userId, displayName, userText, capped, {
+          messageId: message.id,
+          source: "direct",
+          at: message.createdTimestamp,
+        });
         maybeExtractObservations(guildId, userId, displayName, runChain).catch(() => {});
       }
       if (guildId && groupContextLines && groupContextLines.length > 0) {
@@ -401,6 +405,7 @@ async function generateAIReply(message, userText) {
             appendPendingInteraction(
               guildId, entry.userId, entry.displayName,
               entry.line, "",
+              { messageId: entry.messageId, source: "passive", at: entry.at },
             );
           }
         }

--- a/src/ai/group-context.js
+++ b/src/ai/group-context.js
@@ -36,6 +36,10 @@ async function fetchGroupContext(channel, count, beforeMessageId, botUserId) {
         m.author?.globalName ||
         m.author?.username ||
         null,
+      // Identity of the underlying Discord message, so downstream personal-
+      // memory scooping can dedup by messageId instead of by text.
+      messageId: m.id ?? null,
+      at: m.createdTimestamp ?? null,
     });
     if (formatted.length >= count) break;
   }

--- a/src/ai/observation-extractor.js
+++ b/src/ai/observation-extractor.js
@@ -4,6 +4,7 @@ const {
   clearPending,
   appendObservations,
   setConsolidatedProfile,
+  listPendingBacklog,
   PROFILE_MAX_LEN,
 } = require("../user-profile-store");
 const {
@@ -30,19 +31,24 @@ const CONSOLIDATE_MAX_TOKENS = 500;
 const extractInFlight = new Set();
 const consolidateInFlight = new Set();
 
-const EXTRACTION_PERSONA = `你是一個觀察力很強的助手。你的工作是從對話紀錄中提取使用者的**穩定人格特徵**。
+const EXTRACTION_PERSONA = `你是一個中立的行為紀錄助手。你的工作是從對話紀錄中提取使用者的**穩定人格特徵**，並為每一條標註依據。
+
+## 資料格式
+對話紀錄逐條編號。【直接互動】是使用者直接對西寶說的話（含西寶回覆）；【旁聽片段】是使用者在群組裡的一般發言，只是被旁聽到，**證據力較低**。
 
 ## 規則
 - 只記錄**穩定偏好、性格傾向、說話語氣、常聊話題、興趣、互動偏好**（例如：常用特定口頭禪、對某話題持續有興趣、說話語氣特徵）
-- 可根據使用者直接 @ 西寶的內容，以及非常近的群組脈絡判斷；不要用太遠的群聊片段替個人下結論
+- 用中性、可驗證的行為描述（例：「常用『欠扁』開玩笑」「多次聊到棒球」）；**不要**寫評價式或討好式形容（例：幽默、擅長、很有魅力），也不要貶低
+- 特徵主要須由【直接互動】支持；【旁聽片段】只能當輔助，或同一特徵出現在多則**不同編號**的旁聽時才可採用
 - **不記錄**：單次情緒、暫時狀態、敏感推測（政治傾向、健康、性取向、宗教、真實身份）
 - 不確定就回空 observations
 - 每條 observation 不超過 30 字
-- confidence 0~1，只有多次出現的特徵才給高 confidence
+- evidence 必填：支持該條觀察的對話編號（數字陣列）；找不到依據的條目不要輸出
+- confidence 0~1，同一特徵出現在越多**不同編號**才能給越高
 
 ## 輸出格式
 嚴格回傳 JSON，不要加任何其他文字：
-{"observations":[{"text":"觀察內容","confidence":0.7}]}
+{"observations":[{"text":"觀察內容","confidence":0.7,"evidence":[1,3]}]}
 
 最多 3 條。沒有值得記的就回：
 {"observations":[]}`;
@@ -68,16 +74,41 @@ function shouldExtract(guildId, userId) {
   return false;
 }
 
+// Old records predate the source field: a recorded assistant reply means the
+// user talked to 西寶 directly, an empty one means a passively scooped
+// group-context line.
+function pendingSource(p) {
+  if (p?.source === "passive" || p?.source === "direct") return p.source;
+  return p?.assistantText ? "direct" : "passive";
+}
+
 function buildExtractionTurns(pending) {
-  const lines = pending.map(
-    (p) => `使用者：${p.userText || "（空）"}\n西寶：${p.assistantText || "（空）"}`,
-  );
+  const lines = pending.map((p, i) => {
+    const n = i + 1;
+    if (pendingSource(p) === "passive") {
+      return `#${n}【旁聽片段】${p.userText || "（空）"}`;
+    }
+    return `#${n}【直接互動】使用者：${p.userText || "（空）"}\n西寶：${p.assistantText || "（空）"}`;
+  });
   return [
     {
       role: "user",
-      content: `以下是最近的對話紀錄，請從中提取使用者的穩定人格特徵：\n\n${lines.join("\n\n")}`,
+      content: `以下是最近的對話紀錄（逐條編號），請從中提取使用者的穩定人格特徵，並在 evidence 附上依據的編號：\n\n${lines.join("\n\n")}`,
     },
   ];
+}
+
+function parseEvidenceIndices(value) {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set();
+  const out = [];
+  for (const v of value) {
+    const n = Number(v);
+    if (!Number.isInteger(n) || n < 1 || seen.has(n)) continue;
+    seen.add(n);
+    out.push(n);
+  }
+  return out;
 }
 
 function parseExtractionResult(text) {
@@ -92,11 +123,71 @@ function parseExtractionResult(text) {
       .map((o) => ({
         text: o.text.slice(0, 120),
         confidence: o.confidence,
+        evidence: parseEvidenceIndices(o.evidence),
       }));
   } catch {
     console.warn("[observation-extractor] failed to parse LLM output");
     return [];
   }
+}
+
+// Confidence is code-enforced, not LLM-trusted: resolve the model's evidence
+// indices to real {messageId, at, source} records, then cap confidence by
+// what the evidence actually supports. Passive-only evidence can never carry
+// a high-confidence trait on its own.
+const EVIDENCE_CAP_NO_MESSAGE = 0.3;
+const EVIDENCE_CAP_SINGLE_MESSAGE = 0.4;
+const EVIDENCE_CAP_PASSIVE_ONLY = 0.5;
+
+function attachEvidence(observations, pending) {
+  return observations.map((o) => {
+    const evidence = [];
+    const seen = new Set();
+    for (const idx of o.evidence || []) {
+      const p = pending[idx - 1];
+      if (!p?.messageId || seen.has(p.messageId)) continue;
+      seen.add(p.messageId);
+      evidence.push({
+        messageId: p.messageId,
+        at: typeof p.at === "number" ? p.at : null,
+        source: pendingSource(p),
+      });
+    }
+    let confidence =
+      typeof o.confidence === "number" && Number.isFinite(o.confidence)
+        ? o.confidence
+        : 0.5;
+    if (evidence.length === 0) {
+      confidence = Math.min(confidence, EVIDENCE_CAP_NO_MESSAGE);
+    } else if (evidence.length === 1) {
+      confidence = Math.min(confidence, EVIDENCE_CAP_SINGLE_MESSAGE);
+    }
+    if (evidence.length > 0 && evidence.every((e) => e.source === "passive")) {
+      confidence = Math.min(confidence, EVIDENCE_CAP_PASSIVE_ONLY);
+    }
+    return { ...o, confidence, evidence };
+  });
+}
+
+// The bar an observation must clear before consolidation may state it as a
+// fact: at least 3 distinct source messages, or 2 distinct messages far
+// enough apart in time that it wasn't one burst of the same moment.
+const STABLE_MIN_DISTINCT_MESSAGES = 3;
+const STABLE_TIME_GAP_MS = 6 * 60 * 60 * 1000;
+
+function isStableObservation(obs) {
+  const evidence = Array.isArray(obs?.evidence) ? obs.evidence : [];
+  const ids = new Set(evidence.map((e) => e?.messageId).filter(Boolean));
+  if (ids.size >= STABLE_MIN_DISTINCT_MESSAGES) return true;
+  if (ids.size >= 2) {
+    const ats = evidence
+      .map((e) => (typeof e?.at === "number" ? e.at : null))
+      .filter((v) => v !== null);
+    if (ats.length >= 2 && Math.max(...ats) - Math.min(...ats) >= STABLE_TIME_GAP_MS) {
+      return true;
+    }
+  }
+  return false;
 }
 
 async function maybeExtractObservations(guildId, userId, displayName, runChain) {
@@ -123,9 +214,9 @@ async function maybeExtractObservations(guildId, userId, displayName, runChain) 
       return;
     }
 
-    const observations = parseExtractionResult(result.text);
+    const observations = attachEvidence(parseExtractionResult(result.text), pending);
     console.log(
-      `[observation-extractor] user=${userId} provider=${result.provider.label} extracted=${observations.length} from=${pending.length} pending`,
+      `[observation-extractor] user=${userId} provider=${result.provider.label} extracted=${observations.length} from=${pending.length} pending evidence=${observations.map((o) => o.evidence.length).join(",") || "-"}`,
     );
 
     if (observations.length > 0) {
@@ -143,11 +234,14 @@ async function maybeExtractObservations(guildId, userId, displayName, runChain) 
 
 // --- Consolidation ---
 
-const CONSOLIDATION_PERSONA = `你是一個擅長整理人格資料的助手。你的工作是把零散的觀察合併成一段簡潔的人格摘要。
+const CONSOLIDATION_PERSONA = `你是一個中立的人格資料整理助手。你的工作是把零散的觀察合併成一段簡潔、可查證的人格摘要。
 
 ## 規則
-- 合併重複或相似的觀察，保留最有代表性的描述
-- 只保留穩定、可用於日常互動的資訊（說話風格、興趣、互動偏好）
+- 摘要裡的每一句話都必須對應到某條觀察；沒有觀察支持的內容一律不寫
+- 用中性、行為式描述（他說了什麼、常聊什麼、怎麼互動）；**禁止**沒有直接佐證的評價或吹捧詞（例：靈魂人物、觀察精準、擅長、高情商、很有魅力），也不要貶低
+- 「已達證據門檻」區的觀察可以直接寫進摘要
+- 「證據不足」區的觀察**不可寫成斷言**：要嘛忽略，要嘛用「或許」「有時」輕輕帶過
+- 合併重複或相似的觀察，保留最具體的行為描述
 - **不寫**：敏感推測（政治傾向、健康、性取向、宗教、真實身份）、單次情緒、「某天說過什麼」流水帳
 - 如果觀察不足以形成有意義的摘要，就保留舊 profile 原文
 - 摘要用繁體中文，自然口語，不要條列式
@@ -177,16 +271,32 @@ function shouldConsolidate(guildId, userId) {
   return false;
 }
 
+function describeObservationEvidence(obs) {
+  const evidence = Array.isArray(obs?.evidence) ? obs.evidence : [];
+  const ids = new Set(evidence.map((e) => e?.messageId).filter(Boolean));
+  if (ids.size === 0) return "無訊息佐證";
+  return `${ids.size} 則訊息佐證`;
+}
+
 function buildConsolidationTurns(entry) {
   const parts = [];
   if (entry.profile) {
     parts.push(`## 既有人格摘要\n${entry.profile}`);
   }
   parts.push(`## 暱稱\n${entry.name || "未知"}`);
-  const obsLines = (entry.observations || [])
-    .map((o) => `- ${o.text}（信心 ${o.confidence}）`)
-    .join("\n");
-  parts.push(`## 新觀察\n${obsLines}`);
+
+  const stable = [];
+  const weak = [];
+  for (const o of entry.observations || []) {
+    (isStableObservation(o) ? stable : weak).push(o);
+  }
+  const fmt = (o) => `- ${o.text}（信心 ${o.confidence}，${describeObservationEvidence(o)}）`;
+  if (stable.length > 0) {
+    parts.push(`## 已達證據門檻的觀察（可寫進摘要）\n${stable.map(fmt).join("\n")}`);
+  }
+  if (weak.length > 0) {
+    parts.push(`## 證據不足的觀察（不可寫成斷言，可忽略或用「或許」帶過）\n${weak.map(fmt).join("\n")}`);
+  }
   return [
     {
       role: "user",
@@ -424,6 +534,53 @@ async function maybeGuildConsolidate(guildId, runChain) {
   }
 }
 
+// --- Backlog sweep ---
+// Extraction normally piggybacks on the user's OWN next successful AI reply.
+// Passively-scooped users (active in channel, rarely @ the bot) never hit
+// that trigger, so their pending backlog only ever grows. The sweep drains
+// it on a timer instead: a few users per pass, oldest-starved first, and
+// only when their backlog has been quiet for a while (not mid-conversation).
+
+const BACKLOG_SWEEP_MAX_USERS = 3;
+const BACKLOG_SWEEP_MIN_IDLE_MS = 10 * 60 * 1000;
+
+function selectBacklogUsers(backlog, options = {}) {
+  const {
+    now = Date.now(),
+    maxUsers = BACKLOG_SWEEP_MAX_USERS,
+    minIdleMs = BACKLOG_SWEEP_MIN_IDLE_MS,
+  } = options;
+  return backlog
+    .filter((b) => now - (b.lastPendingAt || 0) >= minIdleMs)
+    .sort((a, b) => (a.lastExtractedAt || 0) - (b.lastExtractedAt || 0))
+    .slice(0, maxUsers);
+}
+
+async function sweepPendingBacklog(buildRunChain, options = {}) {
+  if (typeof buildRunChain !== "function") return 0;
+  const backlog = listPendingBacklog(EXTRACT_MIN_COUNT);
+  const picked = selectBacklogUsers(backlog, options);
+  let processed = 0;
+  for (const item of picked) {
+    try {
+      const runChain = buildRunChain(item.guildId);
+      if (!runChain) continue;
+      await maybeExtractObservations(item.guildId, item.userId, item.name, runChain);
+      processed++;
+    } catch (err) {
+      console.warn(
+        `[backlog-sweep] guild=${item.guildId} user=${item.userId} error: ${err.message}`,
+      );
+    }
+  }
+  if (backlog.length > 0) {
+    console.log(
+      `[backlog-sweep] backlog=${backlog.length} eligible=${picked.length} processed=${processed}`,
+    );
+  }
+  return processed;
+}
+
 function resetForTests() {
   extractInFlight.clear();
   consolidateInFlight.clear();
@@ -442,9 +599,19 @@ module.exports = {
   CONSOLIDATE_MAX_TOTAL_CHARS,
   CONSOLIDATE_TIME_THRESHOLD_MS,
   CONSOLIDATION_PERSONA,
+  STABLE_MIN_DISTINCT_MESSAGES,
+  STABLE_TIME_GAP_MS,
+  BACKLOG_SWEEP_MAX_USERS,
+  BACKLOG_SWEEP_MIN_IDLE_MS,
   shouldExtract,
   buildExtractionTurns,
   parseExtractionResult,
+  parseEvidenceIndices,
+  attachEvidence,
+  isStableObservation,
+  describeObservationEvidence,
+  selectBacklogUsers,
+  sweepPendingBacklog,
   maybeExtractObservations,
   shouldConsolidate,
   buildConsolidationTurns,

--- a/src/ai/profile-sweep.js
+++ b/src/ai/profile-sweep.js
@@ -1,0 +1,58 @@
+// Timer wiring for the personal-memory backlog sweep. Lives outside
+// observation-extractor so the extractor never has to import chain.js
+// (chain.js requires the extractor — importing back would be circular).
+const { AI_LONG_TERM_MEMORY_ENABLED, PROFILE_SWEEP_INTERVAL_MS } = require("../config");
+const { buildGuildChain, runProviderChain } = require("./chain");
+const { getTierConfig } = require("../tier-config");
+const { sweepPendingBacklog } = require("./observation-extractor");
+
+// First pass runs shortly after startup so an existing backlog doesn't wait
+// a full interval; steady state is one pass per PROFILE_SWEEP_INTERVAL_MS.
+const PROFILE_SWEEP_STARTUP_DELAY_MS = 5 * 60 * 1000;
+
+let startupTimer = null;
+let intervalTimer = null;
+
+function buildRunChainForGuild(guildId) {
+  const tierConfig = getTierConfig(guildId);
+  const { chain } = buildGuildChain(guildId, tierConfig);
+  if (chain.length === 0) return null;
+  return (turns, persona, maxTokens) =>
+    runProviderChain(chain, turns, persona, maxTokens);
+}
+
+function runSweep() {
+  sweepPendingBacklog(buildRunChainForGuild).catch((err) => {
+    console.warn(`[backlog-sweep] pass failed: ${err.message}`);
+  });
+}
+
+function startProfileSweepTimer() {
+  if (!AI_LONG_TERM_MEMORY_ENABLED || PROFILE_SWEEP_INTERVAL_MS <= 0) return;
+  if (intervalTimer) return;
+  startupTimer = setTimeout(runSweep, PROFILE_SWEEP_STARTUP_DELAY_MS);
+  startupTimer.unref?.();
+  intervalTimer = setInterval(runSweep, PROFILE_SWEEP_INTERVAL_MS);
+  intervalTimer.unref?.();
+  console.log(
+    `[backlog-sweep] timer started interval=${PROFILE_SWEEP_INTERVAL_MS}ms`,
+  );
+}
+
+function stopProfileSweepTimer() {
+  if (startupTimer) {
+    clearTimeout(startupTimer);
+    startupTimer = null;
+  }
+  if (intervalTimer) {
+    clearInterval(intervalTimer);
+    intervalTimer = null;
+  }
+}
+
+module.exports = {
+  PROFILE_SWEEP_STARTUP_DELAY_MS,
+  buildRunChainForGuild,
+  startProfileSweepTimer,
+  stopProfileSweepTimer,
+};

--- a/src/commands.js
+++ b/src/commands.js
@@ -32,6 +32,10 @@ const {
 } = require("./ai/guild-key-store");
 const { getUsage } = require("./ai/rate-limiter");
 const {
+  isStableObservation,
+  describeObservationEvidence,
+} = require("./ai/observation-extractor");
+const {
   DEEPSEEK_MODEL,
   DEEPSEEK_MODEL_FREE,
   DEEPSEEK_PREMIUM_GUILD_IDS,
@@ -575,7 +579,10 @@ async function handleMemoryCommand(interaction) {
     if (obs.length > 0) {
       lines.push(`\n🔍 **待整理的觀察（${obs.length} 條）**`);
       for (const o of obs.slice(0, 10)) {
-        lines.push(`- ${o.text}（信心 ${o.confidence}）`);
+        const stability = isStableObservation(o) ? "" : "，未達穩定門檻";
+        lines.push(
+          `- ${o.text}（信心 ${o.confidence}，${describeObservationEvidence(o)}${stability}）`,
+        );
       }
       if (obs.length > 10) lines.push(`…還有 ${obs.length - 10} 條`);
     }

--- a/src/config.js
+++ b/src/config.js
@@ -149,6 +149,11 @@ module.exports = {
   AI_PROVIDER_FORCE: (process.env.AI_PROVIDER || "").toLowerCase(),
   AI_LONG_TERM_MEMORY_ENABLED:
     (process.env.AI_LONG_TERM_MEMORY_ENABLED || "true").toLowerCase() === "true",
+  // Personal-memory backlog sweep cadence; "0" disables the sweep entirely.
+  PROFILE_SWEEP_INTERVAL_MS:
+    process.env.PROFILE_SWEEP_INTERVAL_MS === "0"
+      ? 0
+      : parsePositiveIntEnv("PROFILE_SWEEP_INTERVAL_MS", 60 * 60 * 1000),
   EMOJI_TRUSTED_GUILD_IDS: parseCsvEnv("EMOJI_TRUSTED_GUILD_IDS"),
   AI_PERSONA: process.env.AI_PERSONA || DEFAULT_AI_PERSONA,
   DEFAULT_AI_PERSONA,

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ const { handleReactionDelete } = require("./reaction-delete");
 const { ensureApplicationCommands, handleInteraction } = require("./commands");
 const { AI_PROVIDER_CHAIN } = require("./ai/chain");
 const { startMemorySweepTimer, stopMemorySweepTimer } = require("./ai/memory");
+const { startProfileSweepTimer, stopProfileSweepTimer } = require("./ai/profile-sweep");
 const { startScheduler, stopScheduler } = require("./scheduler");
 const {
   recordMessage: recordFamiliarityMessage,
@@ -229,6 +230,7 @@ client.on("messageCreate", async (message) => {
 });
 
 startMemorySweepTimer();
+startProfileSweepTimer();
 
 // Last-resort safety net. The watchdog cron is currently disabled, so a
 // process exit means 西寶 stays dead until a manual restart. A single
@@ -246,6 +248,7 @@ for (const signal of ["SIGINT", "SIGTERM"]) {
   process.once(signal, () => {
     stopScheduler();
     stopMemorySweepTimer();
+    stopProfileSweepTimer();
     flushFamiliarity();
     stopFamiliarityFlushTimer();
     process.exit(0);

--- a/src/user-profile-store.js
+++ b/src/user-profile-store.js
@@ -8,6 +8,8 @@ const BAK_PATH = STORE_PATH + ".bak";
 const OBSERVATION_MAX_LEN = 120;
 const PROFILE_MAX_LEN = 500;
 const PENDING_TEXT_MAX_LEN = 500;
+const PENDING_MAX_COUNT = 60;
+const EVIDENCE_MAX_PER_OBSERVATION = 10;
 const RECENT_OBSERVATIONS_PROMPT_COUNT = 3;
 const CONTROL_CHARS_RE = /[\x00-\x1f\x7f-\x9f]/g;
 
@@ -71,21 +73,41 @@ function capText(text, limit) {
   return text.replace(CONTROL_CHARS_RE, " ").trim().slice(0, limit);
 }
 
-function appendPendingInteraction(guildId, userId, displayName, userText, assistantText) {
-  if (!guildId || !userId) return;
+// meta: { messageId, source: "direct"|"passive", at }. Dedup is by Discord
+// messageId ONLY — never by text. Repeating the same sentence across messages
+// can itself be a personality trait; the same message scooped twice (passive
+// group-context re-reads, direct + later passive overlap) is the only certain
+// duplicate. Entries without a messageId are never deduped.
+function appendPendingInteraction(guildId, userId, displayName, userText, assistantText, meta = {}) {
+  if (!guildId || !userId) return false;
   const data = load();
   if (!data[guildId]) data[guildId] = {};
   const entry = data[guildId][userId] || makeEmptyEntry(displayName);
   if (displayName) entry.name = sanitizeName(displayName);
   if (!entry.pendingInteractions) entry.pendingInteractions = [];
+
+  const messageId = meta.messageId ? String(meta.messageId) : null;
+  if (messageId && entry.pendingInteractions.some((p) => p.messageId === messageId)) {
+    return false;
+  }
+
   entry.pendingInteractions.push({
     userText: capText(userText, PENDING_TEXT_MAX_LEN),
     assistantText: capText(assistantText, PENDING_TEXT_MAX_LEN),
-    at: Date.now(),
+    at: typeof meta.at === "number" && Number.isFinite(meta.at) ? meta.at : Date.now(),
+    messageId,
+    source: meta.source === "passive" ? "passive" : "direct",
   });
+  if (entry.pendingInteractions.length > PENDING_MAX_COUNT) {
+    entry.pendingInteractions.splice(
+      0,
+      entry.pendingInteractions.length - PENDING_MAX_COUNT,
+    );
+  }
   entry.updatedAt = Date.now();
   data[guildId][userId] = entry;
   save();
+  return true;
 }
 
 function getPendingInteractions(guildId, userId) {
@@ -110,6 +132,32 @@ function getUserProfile(guildId, userId) {
   return data[guildId]?.[userId] ?? null;
 }
 
+// Evidence items are { messageId, at, source } pointing at the Discord
+// messages an observation was derived from. Items without a messageId are
+// dropped — they can never satisfy the stability bar, so storing them would
+// only fake support.
+function sanitizeEvidence(list) {
+  if (!Array.isArray(list)) return [];
+  const seen = new Set();
+  const out = [];
+  for (const item of list) {
+    const messageId = item?.messageId ? String(item.messageId) : null;
+    if (!messageId || seen.has(messageId)) continue;
+    seen.add(messageId);
+    out.push({
+      messageId,
+      at: typeof item.at === "number" && Number.isFinite(item.at) ? item.at : null,
+      source: item.source === "passive" ? "passive" : "direct",
+    });
+    if (out.length >= EVIDENCE_MAX_PER_OBSERVATION) break;
+  }
+  return out;
+}
+
+function mergeEvidence(existing, incoming) {
+  return sanitizeEvidence([...(existing || []), ...(incoming || [])]);
+}
+
 function appendObservations(guildId, userId, displayName, observations) {
   if (!guildId || !userId) return;
   if (!Array.isArray(observations) || observations.length === 0) return;
@@ -125,10 +173,25 @@ function appendObservations(guildId, userId, displayName, observations) {
   for (const obs of observations) {
     const text = sanitizeObservationText(obs.text);
     if (!text) continue;
+    const evidence = sanitizeEvidence(obs.evidence);
+    // Same trait re-extracted in a later batch: pool the evidence instead of
+    // duplicating the row — accumulated distinct messageIds are what let an
+    // observation cross the stability bar over time.
+    const existing = entry.observations.find((o) => o.text === text);
+    if (existing) {
+      existing.evidence = mergeEvidence(existing.evidence, evidence);
+      existing.confidence = Math.max(
+        clampConfidence(existing.confidence),
+        clampConfidence(obs.confidence),
+      );
+      existing.at = now;
+      continue;
+    }
     entry.observations.push({
       text,
       at: typeof obs.at === "number" ? obs.at : now,
       confidence: clampConfidence(obs.confidence),
+      evidence,
     });
   }
 
@@ -205,6 +268,29 @@ function listUserProfiles(guildId) {
   }));
 }
 
+// Users whose pending backlog reached minCount, across all guilds — feed for
+// the scheduled backlog sweep, so passively-scooped users don't wait forever
+// for their own next @mention to trigger extraction.
+function listPendingBacklog(minCount = 1) {
+  const data = load();
+  const out = [];
+  for (const [guildId, users] of Object.entries(data)) {
+    for (const [userId, entry] of Object.entries(users)) {
+      const pending = entry?.pendingInteractions ?? [];
+      if (pending.length < minCount) continue;
+      out.push({
+        guildId,
+        userId,
+        name: entry.name || null,
+        pendingCount: pending.length,
+        lastPendingAt: pending[pending.length - 1]?.at ?? 0,
+        lastExtractedAt: entry.lastExtractedAt ?? 0,
+      });
+    }
+  }
+  return out;
+}
+
 function flush() {
   save();
 }
@@ -219,8 +305,11 @@ module.exports = {
   PROFILE_MAX_LEN,
   PROFILE_PROMPT_MAX_LEN,
   PENDING_TEXT_MAX_LEN,
+  PENDING_MAX_COUNT,
+  EVIDENCE_MAX_PER_OBSERVATION,
   RECENT_OBSERVATIONS_PROMPT_COUNT,
   getUserProfile,
+  listPendingBacklog,
   appendPendingInteraction,
   getPendingInteractions,
   clearPending,


### PR DESCRIPTION
## 背景

2026-07-19 使用者用「西寶對你的記憶」查看時發現兩個問題：(1) 待萃取互動堆到 30 筆——被動蒐集（別人 @西寶 時撈最近 3 行群組脈絡）只進不出，萃取只在本人直接互動時觸發；(2) 摘要偏吹捧、部分觀察疑似單次發言就下結論，且被動蒐集無去重，同句重複入庫會偽裝成「多次出現」灌高信心。

## 五個修正（依優先序）

1. **messageId 去重**（不用文字去重）：pending 每筆帶 Discord `messageId`，同 id 直接跳過。重複講同一句話本身可能是人格特徵，文字去重會誤殺；同一則訊息被重複撈取才是確定的重複。
2. **記錄資料來源**：每筆 pending 標 `direct`（本人 @西寶）或 `passive`（旁聽撈取）。萃取 prompt 分【直接互動】/【旁聽片段】並明定旁聽權重較低；全旁聽證據的觀察 confidence 程式強制 ≤0.5。
3. **證據門檻**：LLM 萃取必須附 `evidence`（依據的對話編號），程式解析成 `{messageId, at, source}` 存進 observation。信心由程式蓋帽：無佐證 ≤0.3、單則 ≤0.4。穩定特徵門檻：**≥3 個不同 messageId，或 2 個相隔 ≥6 小時**；consolidation 把觀察分「已達門檻（可寫進摘要）」與「證據不足（禁寫成斷言，只能或許/有時帶過）」。同文觀察跨批合併、證據聯集——特徵可以隨時間「掙得」穩定性。
4. **中性 prompt**：兩個 persona 改寫為中性行為描述、每句對應觀察，明文禁止「靈魂人物」「觀察精準」「擅長」等無佐證吹捧詞。
5. **Backlog sweep**（`src/ai/profile-sweep.js`）：每小時（`PROFILE_SWEEP_INTERVAL_MS`，`0` 可關）掃 pending ≥5 的使用者，每輪最多 3 人、跳過 10 分鐘內還在講話的人、最久沒萃取的優先。解決被動堆積永遠等本人 @ 的問題。

另外：pending 上限 60 筆（丟最舊）；`/memory show` 每條觀察顯示佐證數與是否達穩定門檻。

## 測試

- `npm test` 全過：pure 203、routing 34、circuit 40。
- 新增 13 個測試：messageId 去重（含「同文不同訊息不誤殺」）、source 標記與舊資料推斷、evidence 解析/映射/信心蓋帽、穩定門檻、同文合併證據聯集、consolidation 分區、sweep 選人（忙碌排除/飢餓優先/上限）。
- 既有測試修一處：`shouldConsolidate` 字數門檻測試原本用 11 條同文觀察，同文合併後改用相異文字。

## 部署備註

merge 到 main 後需再併回 `deploy/story-coherence`（prod）——`chain.js`/`group-context.js`/`commands.js` 兩邊有 diff（kimi/recap 等），衝突需人工看一下；`observation-extractor.js`/`user-profile-store.js` 兩邊本來一致，會乾淨合併。既有 data 無需遷移：舊 pending 缺 `messageId`/`source` 會自動推斷（有回覆=direct），舊 observations 無 evidence 視為「證據不足」——這正是我們要的保守行為。

🤖 Generated with [Claude Code](https://claude.com/claude-code)