### PR TITLE
fix: redistill guard self-matched its own pgrep shell

### DIFF
--- a/scripts/redistill-profiles.js
+++ b/scripts/redistill-profiles.js
@@ -52,7 +52,9 @@ const MIGRATION_NOTE =
 
 function botIsRunning() {
   try {
-    const out = execSync('pgrep -f "src/index.js" || true', { encoding: "utf8" });
+    // [s]rc bracket trick: the pgrep shell's own cmdline contains the literal
+    // "[s]rc/index.js", which the regex does not match — no self-match.
+    const out = execSync('pgrep -f "[s]rc/index\\.js" || true', { encoding: "utf8" });
     return out.trim().length > 0;
   } catch {
     return false;


### PR DESCRIPTION
`execSync('pgrep -f \"src/index.js\"')` 起的 sh 子行程 cmdline 本身就含這個字串，pgrep 抓到自己 → 護欄永遠誤判 bot 在跑。改用 `[s]rc` bracket 模式（regex 匹配 src/…，但字面 cmdline 是 [s]rc/… 不自我匹配）。已在 deploy/story-coherence 以同一 commit 實戰驗證（52 筆重蒸餾成功）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)