### PR TITLE
docs: prod = 主 checkout 的當前分支；worktree 跑測試會生假 data/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,11 +50,12 @@ CommonJS modules under `src/`. Entry point [src/index.js](src/index.js) is just 
    ln -sf "$(pwd)/node_modules" ../dspb-<feature>/node_modules   #   so link (or reinstall) per worktree
    ```
    Work, commit, and run/deploy the bot from that worktree. `git worktree list` shows who's on what; `git worktree remove <path>` when done. (The harness may reset cwd back to the main dir between commands — address the worktree by absolute path or `git -C <path>`.)
+   ⚠️ **`npm test` in a worktree creates a fake `data/`.** The stores write relative to cwd, so a test run leaves a real `data/` holding fixtures (`sk-mykey`). Any later script you point at real guild data then reads the fixtures. Before touching live data from a worktree: `rm -rf data && ln -s "$(pwd)/../discord-social-preview-bot/data" data`.
    ⚠️ **Never `git add -A` in a worktree before checking `git status` for the `.env`/`node_modules`/`data` symlinks.** A trailing-slash gitignore pattern (`data/`) does NOT match a symlink, so `add -A` commits it — and checking that branch out in the main tree then **replaces the real directory with a self-pointing link, deleting its contents** (lost `data/` once, 2026-07-05; recovered from the running bot's memory). `.gitignore` now uses slash-less patterns to block this, but older branches may predate the fix — verify with `git ls-tree <branch> -- data node_modules .env` before any checkout in the main tree.
 1. New work → branch off `main` (`feat/xxx`, `fix/xxx`, `docs/xxx`) in its own worktree. No direct commits to `main`.
 2. Commit on branch. Run `npm test` (all three smokes) before requesting merge.
 3. Open PR → merge to `main`.
-4. After merge, **provide redeploy steps** (see [deploy.md](docs/deploy.md)) — the host tracks GitHub, not the local tree.
+4. After merge, redeploy (see [deploy.md](docs/deploy.md)). **Prod is the main checkout's working tree on whatever branch it currently has** — there is no `deploy/*` branch; check `git branch --show-current` there and merge the PR into *that* branch, so deploying never needs a `git checkout` in the shared folder.
 5. Status reports: include **current branch, commit hash, push status, test status**. All human-facing communication in 繁體中文.
 
 ## Quick start (local)

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -16,6 +16,13 @@ macOS convenience scripts: `start-bot.command` / `stop-bot.command`.
 
 Bot runs 24/7 on **this machine** (the same host Claude Code runs on) via `nohup`. No SSH needed — just run commands directly. Path: `~/side_projects/apps/discord-social-preview-bot/`.
 
+**Production is the main checkout's working tree, whatever branch it is on** — `scripts/bot-watchdog.sh` hardcodes `REPO=~/side_projects/apps/discord-social-preview-bot` and relaunches `node src/index.js` from there. Two consequences:
+
+- **There is no separate deploy branch.** Whatever `git branch --show-current` prints in that folder is what's live (2026-08-29: `fix/recap-deepseek-empty`, not `main` and not a `deploy/*` branch). Check it before assuming.
+- **Uncommitted edits in that working tree go live on the next restart.** Run `git status` before restarting; another session's half-finished work is not your deploy.
+
+A cron watchdog runs every minute and restarts the bot if the process is gone, so `kill <pid>` alone is a valid restart — or run `scripts/bot-watchdog.sh` by hand to skip the wait. Do **not** `pkill -f 'node src/index.js'`: that pattern also matches Claude Code's own tool shells (use `pkill -xf` or the pid).
+
 ### Daily ops
 
 ```bash
@@ -26,14 +33,19 @@ tail -50 ~/side_projects/apps/discord-social-preview-bot/bot.log
 pgrep -f 'node src/index.js'
 ```
 
-### Redeploy after merging to main
+### Redeploy after merging
+
+Merge the PR into **the branch the main checkout is already on** (see above) so the deploy never needs a `git checkout` in that shared folder.
 
 ```bash
 cd ~/side_projects/apps/discord-social-preview-bot
-git pull
-pkill -f 'src/index.js' && sleep 1
-nohup node src/index.js > bot.log 2>&1 &
-sleep 3 && tail -20 bot.log
+git branch --show-current          # confirm this is the branch you merged into
+git status --short                 # anything uncommitted goes live too — check whose it is
+git merge --ff-only origin/<that-branch>
+npm test
+kill "$(pgrep -xf 'node src/index.js')"   # watchdog relaunches within 60s
+./scripts/bot-watchdog.sh                 # or restart immediately
+tail -20 bot.log
 ```
 
 ### Verify restart success


### PR DESCRIPTION
兩件今天部署時撞到、文件沒寫的事。

## 1. deploy.md 的「Redeploy after merging to main」是錯的

`scripts/bot-watchdog.sh` 把 `REPO` 寫死指向主 checkout，並從那裡 relaunch `node src/index.js`——**那個資料夾的 HEAD 就是 prod**，跟 main 或任何 `deploy/*` 分支無關。今天線上跑的是 `fix/recap-deepseek-empty`。

連帶兩個後果寫進文件：

- 沒有 deploy 分支這回事，部署前先 `git branch --show-current`
- **該工作區未提交的改動會在下次重啟時一起上線**。今天就撞到：另一個 session 未完成的 `scripts/start-voice-tts.sh` 改寫拿掉了 seed pin，voice smoke 因此紅一條，而那份改動已經隨重啟生效了

重部署流程改成「把 PR 合進主 checkout 已經在的那支分支」，這樣部署永遠不需要在共用資料夾 `git checkout`（正是 CLAUDE.md 三令五申不能做的事）。

順帶把 `pkill -f 'node src/index.js'` 標成禁用——那個 pattern 會 match Claude Code 自己的 tool shell。改用 pid、`pkill -xf`，或直接跑 watchdog。

## 2. worktree 跑 `npm test` 會生出假的 `data/`

store 模組相對 cwd 寫檔，所以測試跑完會在 worktree 留下一個**真的** `data/` 目錄，裡面是 fixture（`sk-mykey`、`keyed-guild`）。之後任何指向真實 guild 資料的腳本都會讀到假的。今天接真實素材跑 dry run 時踩到兩次。

## 測試

`npm test` 四層全過：228 / 42 / 52 / **16**（在 worktree 跑，voice 全過——反證了主 checkout 那條紅的是未提交檔案造成的）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)