### PR TITLE
docs: 修正 watchdog 狀態與 shadow-deploy 流程 + 抽出 worktrees.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ CommonJS modules under `src/`. Entry point [src/index.js](src/index.js) is just 
 
 ## NEVER
 
-- **NEVER** do feature work in the shared main checkout — and **NEVER** `git checkout` a different branch there — while another session/feature may be active. A working tree's HEAD is a property of the **folder**, not the conversation: every process pointed at that folder (other Claude sessions, your terminals, the running bot's source dir) shares one branch, so a checkout silently stomps all of them. Each concurrent feature gets its **own** `git worktree` — sibling `apps/dspb-<feature>/` (e.g. `dspb-bilibili`, `dspb-imitation`). See the Workflow section.
+- **NEVER** do feature work in the shared main checkout — and **NEVER** `git checkout` a different branch there — while another session/feature may be active. A working tree's HEAD is a property of the **folder**, not the conversation: every process pointed at that folder (other Claude sessions, your terminals, the running bot's source dir) shares one branch, so a checkout silently stomps all of them. Each concurrent feature gets its **own** `git worktree` — sibling `apps/dspb-<feature>/` (e.g. `dspb-bilibili`, `dspb-imitation`). See [`worktrees.md`](docs/worktrees.md).
 - **NEVER** push directly to `main`. All changes go on a branch → PR → merge.
 - **NEVER** merge a branch into `main` without `npm test` passing locally.
 - **NEVER** let a function own more than one responsibility. When adding behaviour, decide if it belongs in an existing function or needs a new one — don't wedge flags into unrelated code.
@@ -43,15 +43,8 @@ CommonJS modules under `src/`. Entry point [src/index.js](src/index.js) is just 
 
 ## Workflow
 
-0. **Isolate parallel work in a `git worktree`.** The main checkout is shared by every process in that folder (other sessions, terminals, the running bot). Do NOT `git checkout` a feature branch there while others are active — spin up a dedicated worktree instead:
-   ```bash
-   git worktree add ../dspb-<feature> feat/<feature>      # sibling of the repo, own branch
-   ln -sf "$(pwd)/.env" ../dspb-<feature>/.env            # .env + node_modules are gitignored,
-   ln -sf "$(pwd)/node_modules" ../dspb-<feature>/node_modules   #   so link (or reinstall) per worktree
-   ```
-   Work, commit, and run/deploy the bot from that worktree. `git worktree list` shows who's on what; `git worktree remove <path>` when done. (The harness may reset cwd back to the main dir between commands — address the worktree by absolute path or `git -C <path>`.)
-   ⚠️ **`npm test` in a worktree creates a fake `data/`.** The stores write relative to cwd, so a test run leaves a real `data/` holding fixtures (`sk-mykey`). Any later script you point at real guild data then reads the fixtures. Before touching live data from a worktree: `rm -rf data && ln -s "$(pwd)/../discord-social-preview-bot/data" data`.
-   ⚠️ **Never `git add -A` in a worktree before checking `git status` for the `.env`/`node_modules`/`data` symlinks.** A trailing-slash gitignore pattern (`data/`) does NOT match a symlink, so `add -A` commits it — and checking that branch out in the main tree then **replaces the real directory with a self-pointing link, deleting its contents** (lost `data/` once, 2026-07-05; recovered from the running bot's memory). `.gitignore` now uses slash-less patterns to block this, but older branches may predate the fix — verify with `git ls-tree <branch> -- data node_modules .env` before any checkout in the main tree.
+0. **Isolate parallel work in a `git worktree`** — never `git checkout` a feature branch in the shared main checkout (that folder is prod, and its HEAD is shared by every process pointed at it). Setup recipe, naming, and teardown in [`worktrees.md`](docs/worktrees.md).
+   ⚠️ 兩個坑都會弄丟真實資料：worktree 裡跑 `npm test` 會生出裝 fixture 的假 `data/`；`git add -A` 會把 `data` symlink commit 進去，之後在主樹 checkout 那支會**刪掉整個 `data/`**（2026-07-05 發生過）。動真資料或 `add -A` 前先讀 [`worktrees.md`](docs/worktrees.md)。
 1. New work → branch off `main` (`feat/xxx`, `fix/xxx`, `docs/xxx`) in its own worktree. No direct commits to `main`.
 2. Commit on branch. Run `npm test` (all three smokes) before requesting merge.
 3. Open PR → merge to `main`.
@@ -80,6 +73,7 @@ Pure data and per-topic depth live under `docs/` so this file stays lean. **They
 - [`ai-providers.md`](docs/ai-providers.md) — provider chain, call shapes, circuit breaker, observability, short-term memory, Gemini billing trap.
 - [`persona.md`](docs/persona.md) — 西寶 persona (narrative-driven), mention routing, fortune weights, `/ai-tier` / `/ai-key`.
 - [`scripts.md`](docs/scripts.md) — three smoke layers and when to run which.
+- [`worktrees.md`](docs/worktrees.md) — 平行開發隔離、假 `data/` 與 symlink 陷阱、shadow-deploy。
 - [`deploy.md`](docs/deploy.md) — local run, SSH deploy, redeploy steps, secrets.
 
 ## Self-evolution

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -76,21 +76,25 @@ grep 'chain exhausted' bot.log   # AI chain drained for every mention
 
 ### Shadow-deploy a branch (test before merge)
 
+Run it from a **worktree**, never by checking the branch out in the main checkout — that folder *is* prod, and its HEAD is shared by every process pointed at it. Worktree rules and traps: [worktrees.md](worktrees.md).
+
 ```bash
-cd ~/side_projects/apps/discord-social-preview-bot
-git fetch origin
-git checkout <branch-name>
-pkill -f 'src/index.js' && sleep 1
-nohup node src/index.js > bot.log 2>&1 &
+cd ~/side_projects/apps
+git -C discord-social-preview-bot worktree add ../dspb-shadow <branch-name>
+ln -sf ~/side_projects/apps/discord-social-preview-bot/.env dspb-shadow/.env
+ln -sf ~/side_projects/apps/discord-social-preview-bot/node_modules dspb-shadow/node_modules
+cd dspb-shadow && nohup node src/index.js > bot.log 2>&1 &
 sleep 3 && tail -20 bot.log
 ```
 
-To roll back:
+⚠️ **Two processes on one token both answer every message.** The `.env` symlink above shares prod's token, so stop prod first — comment out the watchdog cron, then `kill "$(pgrep -xf 'node src/index.js')"` — or give the shadow its own test token instead of the symlink.
+
+Tear down:
 
 ```bash
-git checkout main
-pkill -f 'src/index.js' && sleep 1
-nohup node src/index.js > bot.log 2>&1 &
+kill <shadow-pid>
+git -C ~/side_projects/apps/discord-social-preview-bot worktree remove ../dspb-shadow
+# re-enable the watchdog cron if you disabled it
 ```
 
 ## Secrets
@@ -99,16 +103,18 @@ nohup node src/index.js > bot.log 2>&1 &
 
 ## Auto-restart watchdog
 
-A cron watchdog restarts the bot within ~1 min if its process dies (crash, ENOSPC, reboot). Script: [scripts/bot-watchdog.sh](../scripts/bot-watchdog.sh), installed as `* * * * *` in the user crontab. Restart events log to `/tmp/bot_watchdog.log`; bot stdout still appends to `bot.log`.
-
-**Current status (2026-06): the watchdog cron line is commented out — no auto-restart is active.** If the bot dies it will NOT relaunch on its own; restart it manually via the redeploy steps above. The commented crontab line also still points at the old pre-`apps/` flat path, so it would fail even if uncommented as-is. It's left disabled pending a decision on whether the watchdog should run — **do not re-enable it without confirming that's intended.** If you do re-enable it, first correct the path to the new `apps/` location:
+A cron watchdog relaunches the bot within ~1 min whenever its process is gone — crash, ENOSPC, reboot, or a deliberate `kill`. Script: [scripts/bot-watchdog.sh](../scripts/bot-watchdog.sh), installed in the user crontab as:
 
 ```cron
 * * * * * /home/kojiek/side_projects/apps/discord-social-preview-bot/scripts/bot-watchdog.sh
 ```
 
-- The watchdog matches the process with `pgrep -f '[n]ode src/index.js'` — the `[n]` bracket trick stops the pattern from matching the watchdog's own shell. (Plain `pkill -f 'src/index.js'` from an interactive shell self-matches and can kill the shell — prefer `pgrep -f 'node src/index.js'` → `kill <pid>` for manual ops.)
-- **To stop the bot for maintenance, comment out the cron line first** — otherwise the watchdog relaunches it within a minute.
+**Status: enabled and firing.** Verified 2026-08-29 — the line is in `crontab -l` and `/tmp/bot_watchdog.log` records a restart the same day. (This section previously claimed the cron was commented out; it was not.)
+
+- `REPO` is hardcoded to the main checkout — that is *why* prod is whatever branch that folder is on (see [Production deployment](#production-deployment)).
+- Restart events log to `/tmp/bot_watchdog.log`; bot stdout still appends to `bot.log`.
+- The watchdog finds its target with `pgrep -f '[n]ode src/index.js'` — the `[n]` bracket trick stops the pattern from matching the watchdog's own shell. For manual ops use `pgrep -xf 'node src/index.js'` → `kill <pid>`; plain `pkill -f 'src/index.js'` also matches Claude Code's tool shells.
+- **To stop the bot for maintenance, comment out the cron line first** — otherwise it is back within a minute.
 
 ## Future hardening (not yet done)
 

--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -1,0 +1,52 @@
+# Parallel work: git worktrees
+
+## Why
+
+A working tree's HEAD is a property of the **folder**, not of your conversation. Every process pointed at `apps/discord-social-preview-bot/` — other Claude sessions, your terminals, and the running bot, since `bot-watchdog.sh` relaunches `node src/index.js` from exactly that path — shares one branch. A `git checkout` there silently changes what all of them see, and what is live in production.
+
+So: the main checkout stays on the prod branch. Every concurrent feature gets its own worktree, a sibling `apps/dspb-<feature>/`.
+
+## Setup
+
+```bash
+cd ~/side_projects/apps/discord-social-preview-bot
+git worktree add ../dspb-<feature> -b feat/<feature>          # new branch
+git worktree add ../dspb-<feature> <existing-branch>          # or an existing one
+ln -sf "$(pwd)/.env" ../dspb-<feature>/.env                   # .env + node_modules are
+ln -sf "$(pwd)/node_modules" ../dspb-<feature>/node_modules   #   gitignored — link per worktree
+```
+
+Work, commit, and run the bot from that worktree. The harness may reset cwd back to the main dir between commands — address the worktree by absolute path or `git -C <path>`.
+
+```bash
+git worktree list                    # who is on what
+git worktree remove ../dspb-<feature>   # when the branch is merged
+```
+
+Naming: `dspb-<feature>`, matching the branch (`feat/bilibili-video` → `dspb-bilibili`).
+
+## Trap 1 — `npm test` fabricates a `data/`
+
+The JSON stores resolve their paths **relative to cwd**, so a test run inside a worktree leaves behind a real `data/` directory holding fixtures (`sk-mykey` and friends). It looks exactly like the live one. Any script you later point at "real guild data" from that worktree reads the fixtures instead, and any write lands in the fake copy.
+
+Before touching live data from a worktree:
+
+```bash
+rm -rf data && ln -s "$(pwd)/../discord-social-preview-bot/data" data
+```
+
+## Trap 2 — `git add -A` can commit the symlinks, and that deletes `data/`
+
+A trailing-slash gitignore pattern (`data/`) does **not** match a symlink named `data`. So `git add -A` in a worktree happily stages the `.env` / `node_modules` / `data` links. Checking that branch out in the main tree then replaces the real directory with a link pointing at itself — **deleting its contents**. This happened on 2026-07-05; `data/` was recovered only because the running bot still had it in memory.
+
+`.gitignore` now uses slash-less patterns, which blocks the staging. Older branches predate the fix, so before any checkout in the main tree:
+
+```bash
+git ls-tree <branch> -- data node_modules .env    # must print nothing
+```
+
+And always read `git status` before `git add -A` in a worktree.
+
+## Shadow-deploying from a worktree
+
+Running an unmerged branch against the live bot token is a worktree job, not a checkout. Steps and the two-bots-one-token warning: [deploy.md](deploy.md#shadow-deploy-a-branch-test-before-merge).


### PR DESCRIPTION
接 #62。合進 prod 分支（主 checkout 目前在 `fix/recap-deepseek-empty`）。

## 修的兩個錯（deploy.md）

**1. Auto-restart watchdog 整節是錯的。** 原文寫「Current status (2026-06)：cron 被註解掉，沒有自動重啟…別在沒確認的情況下重新啟用」，而且跟同一份文件 46 行的 `# watchdog relaunches within 60s` 自相矛盾。實測：

```
$ crontab -l | grep watchdog
* * * * * /home/kojiek/side_projects/apps/discord-social-preview-bot/scripts/bot-watchdog.sh
$ tail -1 /tmp/bot_watchdog.log
2026-08-29T16:52:01+0800 watchdog: bot not running, restarted (pid=3108297)
```

改成 enabled，並補上 `REPO` 寫死主 checkout 正是「prod = 那個資料夾的當前分支」的成因。

**2. Shadow-deploy a branch 叫人在主 checkout `git checkout <branch-name>`** —— 就是第一條 NEVER 禁的事，也跟同檔剛修好的 redeploy 一節相反。改成開 worktree 跑，並補上原本沒寫的風險：`.env` symlink 共用 prod token，兩個 process 會同時回每一則訊息。

## 順帶（結構）

CLAUDE.md Workflow 第 0 點的 worktree 食譜（9 行）抽到新的 `docs/worktrees.md`；shadow-deploy 一節也指過去，所以新檔不是為了湊行數的空殼。CLAUDE.md 只留兩行帶後果的 ⚠️（假 `data/`、symlink 刪 `data/`），88 → 82 行，回到自己訂的 ~80 行規則內。

## 測試

`npm test` 三個 smoke 全過（routing / smoke / voice）。順帶當場複現了 trap 1：跑完 worktree 裡真的長出一個裝 fixture 的 `data/guild-api-keys.json`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)