### PR TITLE
fix(rate-limit): 每日額度改用台灣日界線，並讓計數活過重啟

### DIFF
--- a/scripts/smoke-ai-circuit.js
+++ b/scripts/smoke-ai-circuit.js
@@ -57,6 +57,7 @@ const {
 const {
   checkAndIncrement,
   getUsage,
+  todayString,
   resetForTests: resetRateLimiter,
 } = require("../src/ai/rate-limiter");
 
@@ -569,6 +570,37 @@ async function main() {
   it("getUsage returns current count", () => {
     const u = getUsage("g1");
     assert.equal(u.count, 3);
+  });
+  it("day boundary is Taipei midnight, not UTC", () => {
+    // 2026-09-05 16:30Z = 2026-09-06 00:30 in Taipei — already the next day
+    // locally, while UTC still calls it the 5th.
+    assert.equal(todayString(Date.parse("2026-09-05T16:30:00Z")), "2026-09-06");
+    assert.equal(todayString(Date.parse("2026-09-05T15:30:00Z")), "2026-09-05");
+  });
+  it("count resets when the last count was on an earlier Taipei day", () => {
+    resetRateLimiter();
+    const yesterday = Date.parse("2026-09-05T10:00:00Z"); // 09-05 18:00 台灣
+    const today = Date.parse("2026-09-05T16:30:00Z"); //     09-06 00:30 台灣
+    checkAndIncrement("tz-guild", 2, yesterday);
+    checkAndIncrement("tz-guild", 2, yesterday);
+    assert.equal(checkAndIncrement("tz-guild", 2, yesterday).allowed, false);
+    const r = checkAndIncrement("tz-guild", 2, today);
+    assert.equal(r.allowed, true, "new Taipei day should start a fresh count");
+    assert.equal(r.remaining, 1);
+  });
+  it("count survives a restart (persisted to disk)", () => {
+    resetRateLimiter();
+    checkAndIncrement("persist-guild", 3);
+    checkAndIncrement("persist-guild", 3);
+    // resetForTests only drops the in-memory map — the next read reloads the
+    // file, which is what a real process restart does.
+    delete require.cache[require.resolve("../src/ai/rate-limiter")];
+    const reloaded = require("../src/ai/rate-limiter");
+    assert.equal(reloaded.getUsage("persist-guild").count, 2);
+    const r = reloaded.checkAndIncrement("persist-guild", 3);
+    assert.equal(r.allowed, true);
+    assert.equal(r.remaining, 0, "restart must not hand back a fresh quota");
+    assert.equal(reloaded.checkAndIncrement("persist-guild", 3).allowed, false);
   });
   it("reset clears counters", () => {
     resetRateLimiter();

--- a/src/ai/rate-limiter.js
+++ b/src/ai/rate-limiter.js
@@ -1,20 +1,81 @@
-const counters = new Map();
+const fs = require("fs");
+const path = require("path");
 
-function todayString() {
-  return new Date().toISOString().slice(0, 10);
+const STORE_PATH = path.join(__dirname, "..", "..", "data", "ai-daily-usage.json");
+
+// Day boundary follows Taipei, not UTC. With UTC the counter reset landed at
+// 08:00 local — mid-morning, splitting the day the guilds actually experience.
+const DAY_TIMEZONE = "Asia/Taipei";
+
+// en-CA gives YYYY-MM-DD, which sorts and compares as a plain string.
+const dayFormatter = new Intl.DateTimeFormat("en-CA", {
+  timeZone: DAY_TIMEZONE,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
+function todayString(now = Date.now()) {
+  return dayFormatter.format(new Date(now));
 }
 
-function checkAndIncrement(guildId, dailyLimit) {
+let counters = null;
+
+function load() {
+  if (counters !== null) return counters;
+  counters = new Map();
+  try {
+    const parsed = JSON.parse(fs.readFileSync(STORE_PATH, "utf8"));
+    if (parsed && typeof parsed === "object") {
+      for (const [guildId, entry] of Object.entries(parsed)) {
+        if (!entry || typeof entry !== "object") continue;
+        const count = Number(entry.count);
+        if (!entry.date || !Number.isFinite(count)) continue;
+        counters.set(guildId, {
+          date: String(entry.date),
+          count,
+          lastAt: Number(entry.lastAt) || 0,
+        });
+      }
+    }
+  } catch (err) {
+    if (err.code !== "ENOENT") {
+      console.warn(`[rate-limit] failed to read ${STORE_PATH}: ${err.message}`);
+    }
+  }
+  return counters;
+}
+
+// Only today's rows are worth keeping — yesterday's would be discarded on read
+// anyway, so dropping them here keeps the file from growing per guild forever.
+function save(today) {
+  const data = {};
+  for (const [guildId, entry] of load()) {
+    if (entry.date === today) data[guildId] = entry;
+  }
+  try {
+    fs.mkdirSync(path.dirname(STORE_PATH), { recursive: true });
+    fs.writeFileSync(STORE_PATH, JSON.stringify(data, null, 2));
+  } catch (err) {
+    console.warn(`[rate-limit] failed to write ${STORE_PATH}: ${err.message}`);
+  }
+}
+
+function checkAndIncrement(guildId, dailyLimit, now = Date.now()) {
   if (!guildId || !dailyLimit || dailyLimit <= 0) {
     return { allowed: true, remaining: Infinity };
   }
 
-  const today = todayString();
-  let entry = counters.get(guildId);
+  const today = todayString(now);
+  const store = load();
+  let entry = store.get(guildId);
 
+  // The stored date IS the "last counted at" check the reset hinges on: an
+  // entry stamped with any earlier day means the guild's last call was
+  // yesterday or before, so the count starts over.
   if (!entry || entry.date !== today) {
-    entry = { date: today, count: 0 };
-    counters.set(guildId, entry);
+    entry = { date: today, count: 0, lastAt: 0 };
+    store.set(guildId, entry);
   }
 
   if (entry.count >= dailyLimit) {
@@ -22,22 +83,27 @@ function checkAndIncrement(guildId, dailyLimit) {
   }
 
   entry.count += 1;
+  entry.lastAt = now;
+  save(today);
   return { allowed: true, remaining: dailyLimit - entry.count };
 }
 
-function getUsage(guildId) {
+function getUsage(guildId, now = Date.now()) {
   if (!guildId) return null;
-  const today = todayString();
-  const entry = counters.get(guildId);
+  const today = todayString(now);
+  const entry = load().get(guildId);
   if (!entry || entry.date !== today) return { count: 0, date: today };
-  return { count: entry.count, date: entry.date };
+  return { count: entry.count, date: entry.date, lastAt: entry.lastAt };
 }
 
 function resetForTests() {
-  counters.clear();
+  counters = new Map();
 }
 
 module.exports = {
+  STORE_PATH,
+  DAY_TIMEZONE,
+  todayString,
   checkAndIncrement,
   getUsage,
   resetForTests,


### PR DESCRIPTION
## 問題

免費公會的 `AI_FREE_DAILY_LIMIT`（20 次/天）實際上擋不住東西，實測 `bot.log` 近 20 天：

- **計數器是純記憶體 `Map`**，`rate-limiter.js` 沒有任何持久化。近 20 天 bot 重啟了 **20 次**（watchdog cron + 部署），每次都把所有公會的計數清成 0。
- **日界線用 UTC**（`new Date().toISOString().slice(0,10)`），重置點落在 **台灣早上 08:00**，切在使用者的一天中間。
- 結果：上限觸發了 207 次，但最活躍的免費公會單日仍打到 55 則（上限的 2.75 倍）。

## 改動

- 日界線改 `Asia/Taipei`（`Intl.DateTimeFormat("en-CA")` → `YYYY-MM-DD`）。entry 上記的日期就是「上次計數的那一天」，只要不是今天就從 0 重新算 — 不需要另外存 timestamp 來比對。
- 計數落地到 `data/ai-daily-usage.json`。寫入時只保留當天的列，檔案不會隨公會數無限長大。
- `checkAndIncrement` / `getUsage` 收 `now` 參數，讓時區與跨日行為可測。

介面沒變，`chain.js` 與 `commands.js` 的呼叫端不用改。

## 測試

`npm test` 全過（43 passed / 0 failed，circuit 那層）。新增 3 個 case：

- `day boundary is Taipei midnight, not UTC`
- `count resets when the last count was on an earlier Taipei day`
- `count survives a restart (persisted to disk)` — 用 `delete require.cache` 模擬真實重啟

## 順帶發現（未在此 PR 處理）

- `main` 的 `.gitignore` 仍是 `data/` / `node_modules/` 帶斜線的舊版，self-symlink 那個坑在 main 上還沒補（部署分支上有）。
- fallback 鏈的 **groq×2 與 gemini 三層全死**：`llama-3.3-70b-versatile` / `llama-3.1-8b-instant` 回 404 `model_not_found`，`gemini-2.0-flash` 回 404 `no longer available`。近 20 天 652 次呼叫、0 次成功，chain exhausted 359 次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)