### PR TITLE
fix(ai): 給 flash 與 Luna 思考的餘裕，別讓預算全燒在沒人看得到的地方

### DIFF
--- a/scripts/smoke-ai-circuit.js
+++ b/scripts/smoke-ai-circuit.js
@@ -21,7 +21,17 @@ process.env.RECAP_DEEPSEEK_MAX_TOKENS = "1600";
 process.env.RECAP_GEMINI_TIMEOUT_MS = "45000";
 delete process.env.AI_PROVIDER;
 
-const { parseRetryAfterMs, ok, fail, callDeepSeek } = require("../src/ai/providers");
+const {
+  parseRetryAfterMs,
+  ok,
+  fail,
+  callDeepSeek,
+  callOpenAI,
+} = require("../src/ai/providers");
+const {
+  DEEPSEEK_REASONING_HEADROOM,
+  OPENAI_REASONING_HEADROOM,
+} = require("../src/config");
 const {
   getCooldownMs,
   isProviderAvailable,
@@ -183,7 +193,12 @@ async function main() {
       assert.equal(result.ok, true);
       assert.match(String(requestUrl), /api\.openai\.com/);
       assert.equal(requestBody.model, "gpt-5.6-luna");
-      assert.equal(requestBody.max_completion_tokens, 900);
+      // 900 is the display budget; Luna's hidden reasoning is billed against
+      // the same ceiling, so the headroom rides on top of it.
+      assert.equal(
+        requestBody.max_completion_tokens,
+        900 + OPENAI_REASONING_HEADROOM,
+      );
     } finally {
       global.fetch = originalFetch;
     }
@@ -656,6 +671,71 @@ async function main() {
       assert.deepEqual(requestBody.thinking, { type: "enabled" });
       assert.equal(requestBody.reasoning_effort, "high");
       assert.equal(requestBody.max_tokens, 2148);
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
+  // Regression guard for the 42% empty-reply bug (2026-06-01 → 2026-09-06):
+  // the free flash entry ran with reasoningHeadroom 0 while thinking stayed
+  // ON, so v4-flash spent the whole display budget on hidden reasoning and
+  // returned finish_reason=length with no content.
+  await itAsync("free flash entry reserves reasoning headroom", async () => {
+    resetKeyCache();
+    resetRateLimiter();
+    resetCircuitState();
+    let requestBody;
+    const originalFetch = global.fetch;
+    global.fetch = async (_url, options) => {
+      requestBody = JSON.parse(options.body);
+      return {
+        ok: true,
+        headers: { get: () => null },
+        json: async () => ({
+          choices: [{ message: { content: "嗨" }, finish_reason: "stop" }],
+          usage: { prompt_tokens: 10, completion_tokens: 12 },
+        }),
+      };
+    };
+    try {
+      const { chain } = buildGuildChain("free-headroom-guild", briefTier);
+      const dsEntry = chain.find((e) => e.label.startsWith("deepseek:"));
+      assert.ok(dsEntry.label.includes("flash"));
+      await dsEntry.call([{ role: "user", content: "hi" }], "persona", 180);
+      assert.equal(
+        requestBody.max_tokens,
+        180 + DEEPSEEK_REASONING_HEADROOM,
+        "flash must get display budget + headroom, not the bare display budget",
+      );
+      assert.ok(
+        !requestBody.thinking || requestBody.thinking.type !== "disabled",
+        "headroom 0 is only valid when thinking is explicitly disabled",
+      );
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+  await itAsync("callOpenAI reserves reasoning headroom", async () => {
+    let requestBody;
+    const originalFetch = global.fetch;
+    global.fetch = async (_url, options) => {
+      requestBody = JSON.parse(options.body);
+      return {
+        ok: true,
+        headers: { get: () => null },
+        json: async () => ({
+          choices: [{ message: { content: "嗨" }, finish_reason: "stop" }],
+          usage: { prompt_tokens: 10, completion_tokens: 12 },
+        }),
+      };
+    };
+    try {
+      await callOpenAI([{ role: "user", content: "hi" }], "persona", 180);
+      assert.equal(
+        requestBody.max_completion_tokens,
+        180 + OPENAI_REASONING_HEADROOM,
+        "OpenAI bills reasoning against max_completion_tokens too",
+      );
     } finally {
       global.fetch = originalFetch;
     }

--- a/src/ai/chain.js
+++ b/src/ai/chain.js
@@ -292,7 +292,13 @@ function buildGuildChain(guildId, tierConfig, providerOptions = {}) {
     call: (turns, persona, maxTokens) =>
       callDeepSeek(turns, persona, maxTokens, {
         model: DEEPSEEK_MODEL_FREE,
-        reasoningHeadroom: 0,
+        // v4-flash thinks too — the tier system shipped assuming only v4-pro
+        // did, so this entry alone ran with no headroom. It burned the whole
+        // display budget on reasoning and returned empty on 42% of calls
+        // (413/414 were finish_reason=length with completion == reasoning).
+        // Headroom 0 is only correct alongside thinking:{type:"disabled"},
+        // which is how the recap/story chains use it.
+        reasoningHeadroom: DEEPSEEK_REASONING_HEADROOM,
         ...deepSeekOptions,
       }),
   };

--- a/src/ai/providers.js
+++ b/src/ai/providers.js
@@ -3,6 +3,7 @@ const {
   OPENAI_API_KEY,
   OPENAI_MODEL,
   OPENAI_BASE_URL,
+  OPENAI_REASONING_HEADROOM,
   GEMINI_API_KEY,
   GEMINI_MODEL,
   GROQ_API_KEY,
@@ -275,10 +276,14 @@ async function callOpenAI(turns, persona, maxTokens, overrides = {}) {
   const model = overrides.model || OPENAI_MODEL;
   const apiKey = overrides.apiKey || OPENAI_API_KEY;
   const url = overrides.baseUrl || OPENAI_BASE_URL;
+  // maxTokens is a *display* budget. OpenAI bills reasoning against
+  // max_completion_tokens as well, so without headroom a thinking model can
+  // spend the entire budget before emitting a single visible character.
+  const headroom = overrides.reasoningHeadroom ?? OPENAI_REASONING_HEADROOM;
   const body = {
     model,
     messages: buildOpenAIMessages(turns, persona),
-    max_completion_tokens: maxTokens,
+    max_completion_tokens: maxTokens + headroom,
   };
   const label = `openai:${model}`;
 

--- a/src/config.js
+++ b/src/config.js
@@ -280,6 +280,14 @@ module.exports = {
     "STORY_OPENAI_TIMEOUT_MS",
     45000,
   ),
+  // gpt-5.6-luna reasons too, and OpenAI counts those hidden tokens against
+  // max_completion_tokens — so the same starvation that hit DeepSeek applies
+  // here (111 empty finish_reason=length calls, all completion == reasoning).
+  // Measured reasoning on successful calls: p50 75, p99 379, max 512.
+  OPENAI_REASONING_HEADROOM: parsePositiveIntEnv(
+    "OPENAI_REASONING_HEADROOM",
+    768,
+  ),
   GEMINI_API_KEY: process.env.GEMINI_API_KEY,
   GEMINI_MODEL: process.env.GEMINI_MODEL || "gemini-2.0-flash",
   GROQ_API_KEY: process.env.GROQ_API_KEY,


### PR DESCRIPTION
## 問題

免費公會的 `deepseek-v4-flash` **42% 的呼叫回空字串**（`bot.log` 近 20 天 414/985）。

413/414 是 `finish_reason=length` 且 `completion_tokens` **完全等於** `reasoning_tokens` —— 模型把整份預算燒在隱藏推理上，可見內容 0。`completion_tokens` 精準落在三個天花板，一個都不多：

| completion_tokens | 次數 | 對應預算 |
|---|---|---|
| 300 | 275 | `observation-extractor.js` `EXTRACT_MAX_TOKENS` |
| 180 | 89 | `tier-config.js` brief `maxTokens` |
| 500 | 18 | `observation-extractor.js` `CONSOLIDATE_MAX_TOKENS` |

## 根因

`chain.js` 免費那條 flash entry 寫死 `reasoningHeadroom: 0`，而 `providers.js` 是 `max_tokens: maxTokens + headroom` —— 等於把「顯示預算」直接當成總預算。

來自 `925bc72`（2026-06-01，per-guild AI tier）。**同一個 commit** 的 `config.js` 註解已經正確診斷過 v4-pro 的同款問題，但假設 flash 不是思考模型。資料顯示 flash 會思考：成功呼叫的 reasoning 中位數 105 tokens。

對照組乾淨：其他 DeepSeek 進入點都帶 headroom（自帶 key 那條明寫，白名單那條走預設 2048），**v4-pro 近 20 天 empty = 0**。

`reasoningHeadroom: 0` 本身沒錯 —— 它在 recap / story 兩條鏈是對的，因為那兩條同時帶 `thinking: { type: "disabled" }`。錯的是「關了預算卻沒關思考」。

## Luna 是同一個病

`callOpenAI` 直接把 `maxTokens` 當 `max_completion_tokens`，但 OpenAI 的 reasoning tokens 也算在這個額度裡，完全沒有 headroom 概念 → **111 次空回**，同樣全是 `length` + `completion == reasoning`（180 桶 63 次、300 桶 46 次）。

## 改動

- `chain.js` — 免費 flash entry 改吃 `DEEPSEEK_REASONING_HEADROOM`（2048）
- `providers.js` — `callOpenAI` 補上對稱的 headroom
- `config.js` — 新增 `OPENAI_REASONING_HEADROOM`，預設 **768**（實測 Luna 成功呼叫 reasoning p50 75 / p99 379 / max 512）
- `smoke-ai-circuit.js` — 兩個回歸斷言：免費 flash entry 必須帶 headroom 且 thinking 沒被關；`callOpenAI` 的 `max_completion_tokens` 必須是 display + headroom

## 影響

| | |
|---|---|
| 直接浪費 | **$0.48/月**（Flash $0.35 + Luna $0.13），佔總支出 13% |
| 白跑的呼叫 | 525 次 / 20 天 |
| **真正的代價** | 空回 → 掉到 Luna（也可能空）→ groq/gemini 三層全 404 → **359 次 `chain exhausted`，西寶吐罐頭回覆** |
| 副作用 | `checkAndIncrement` 在呼叫前就扣額度，免費公會的 20 次/天被這些空回吃掉 |

headroom 只是抬高上限，實付仍以真正生成的 token 計 —— **修完預期是省錢的**。

## 測試

`npm test` 四層全過：pure 259、routing 60、circuit 54、voice 16，0 failed。

同時更新了 `sends story prompt to OpenAI with max_completion_tokens` 的既有斷言（900 → 900 + headroom）—— 床邊故事走 Luna，本來就有同樣的截斷風險。

## Base

以 `fix/recap-deepseek-empty` 為 base，**不是 `main`** —— `main` 已落後 prod 分支 85 個 commit，連 Luna provider 都還沒有。

🤖 Generated with [Claude Code](https://claude.com/claude-code)