### PR TITLE
fix(ai): 換掉下架的 fallback 模型，別讓整條後援鏈靜靜地死著

### DIFF
--- a/scripts/smoke-ai-circuit.js
+++ b/scripts/smoke-ai-circuit.js
@@ -11,6 +11,11 @@ process.env.DEEPSEEK_API_KEY = process.env.DEEPSEEK_API_KEY || "sk-smoke-dummy";
 process.env.KIMI_API_KEY = process.env.KIMI_API_KEY || "sk-kimi-smoke-dummy";
 process.env.KIMI_ENABLED = "true";
 process.env.GEMINI_API_KEY = process.env.GEMINI_API_KEY || "sk-gemini-smoke-dummy";
+process.env.GROQ_API_KEY = process.env.GROQ_API_KEY || "gsk-groq-smoke-dummy";
+// Assert the shipped default, not whatever the operator has in .env.
+delete process.env.GROQ_MODELS;
+delete process.env.GROQ_MODEL;
+delete process.env.GEMINI_MODEL;
 process.env.OPENAI_API_KEY = process.env.OPENAI_API_KEY || "sk-openai-smoke-dummy";
 process.env.OPENAI_MODEL = process.env.OPENAI_MODEL || "gpt-5.6-luna";
 process.env.STORY_OPENAI_TIMEOUT_MS = "45000";
@@ -27,10 +32,12 @@ const {
   fail,
   callDeepSeek,
   callOpenAI,
+  callGemini,
 } = require("../src/ai/providers");
 const {
   DEEPSEEK_REASONING_HEADROOM,
   OPENAI_REASONING_HEADROOM,
+  GEMINI_REASONING_HEADROOM,
 } = require("../src/config");
 const {
   getCooldownMs,
@@ -137,6 +144,26 @@ async function main() {
   console.log("chat fallback chain");
   it("puts OpenAI Luna first in the shared fallback", () => {
     assert.equal(FALLBACK_CHAIN[0].label, "openai:gpt-5.6-luna");
+  });
+  // The whole fallback tail was 404 for weeks. These pin the models that were
+  // actually verified live against each provider on 2026-09-06.
+  it("carries no decommissioned model ids", () => {
+    const labels = FALLBACK_CHAIN.map((p) => p.label);
+    for (const dead of ["llama-3.3-70b-versatile", "llama-3.1-8b-instant", "gemini-2.0-flash"]) {
+      assert.ok(
+        !labels.some((l) => l.includes(dead)),
+        `${dead} returns 404 model_not_found — fallback would be silently dead`,
+      );
+    }
+  });
+  it("uses a single non-reasoning Groq model", () => {
+    const groq = FALLBACK_CHAIN.filter((p) => p.label.startsWith("groq:"));
+    // Groq's free tier caps output tokens per minute at 1000 and counts
+    // max_tokens as expected output, so a reasoning model here cannot be
+    // given headroom without tripping "Request too large ... on output
+    // tokens". Keep this layer to one model that emits no hidden reasoning.
+    assert.equal(groq.length, 1, `expected exactly one Groq layer, got ${groq.map((p) => p.label)}`);
+    assert.equal(groq[0].label, "groq:qwen/qwen3.8-27b");
   });
 
   console.log("daily recap provider policy");
@@ -710,6 +737,31 @@ async function main() {
       assert.ok(
         !requestBody.thinking || requestBody.thinking.type !== "disabled",
         "headroom 0 is only valid when thinking is explicitly disabled",
+      );
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+  await itAsync("callGemini reserves reasoning headroom", async () => {
+    let requestBody;
+    const originalFetch = global.fetch;
+    global.fetch = async (_url, options) => {
+      requestBody = JSON.parse(options.body);
+      return {
+        ok: true,
+        headers: { get: () => null },
+        json: async () => ({
+          candidates: [{ content: { parts: [{ text: "嗨" }] }, finishReason: "STOP" }],
+          usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, thoughtsTokenCount: 700 },
+        }),
+      };
+    };
+    try {
+      await callGemini([{ role: "user", content: "hi" }], "persona", 180);
+      assert.equal(
+        requestBody.generationConfig.maxOutputTokens,
+        180 + GEMINI_REASONING_HEADROOM,
+        "Gemini bills thoughtsTokenCount against maxOutputTokens too",
       );
     } finally {
       global.fetch = originalFetch;

--- a/src/ai/chain.js
+++ b/src/ai/chain.js
@@ -86,9 +86,11 @@ function getPersonalMemoryContextEntries(groupContextLines, count = PERSONAL_CON
   return groupContextLines.slice(-count);
 }
 
-// Fallback chain shared by all guilds. Luna first: Groq/Gemini models in
-// env are currently 404, and DeepSeek v4-pro chat hits the 25s abort when
-// hidden reasoning runs long (same prompt size, more thinking).
+// Fallback chain shared by all guilds. Luna first because DeepSeek v4-pro
+// chat hits the 25s abort when hidden reasoning runs long (same prompt size,
+// more thinking). The Groq and Gemini layers below it were dead 404s from
+// roughly 2026-08 until 2026-09-06 — model IDs rot silently, and the only
+// symptom is `chain exhausted` in the log.
 function buildFallbackChain() {
   const chain = [];
   const only = AI_PROVIDER_FORCE;

--- a/src/ai/providers.js
+++ b/src/ai/providers.js
@@ -6,6 +6,7 @@ const {
   OPENAI_REASONING_HEADROOM,
   GEMINI_API_KEY,
   GEMINI_MODEL,
+  GEMINI_REASONING_HEADROOM,
   GROQ_API_KEY,
   KIMI_API_KEY,
   KIMI_MODEL,
@@ -138,10 +139,17 @@ async function callGemini(turns, persona, maxTokens, overrides = {}) {
     GEMINI_MODEL,
   )}:generateContent?key=${encodeURIComponent(GEMINI_API_KEY)}`;
 
+  // maxOutputTokens covers thinking as well (usageMetadata.thoughtsTokenCount),
+  // so the display budget alone leaves nothing for the visible answer.
+  const headroom = overrides.reasoningHeadroom ?? GEMINI_REASONING_HEADROOM;
   const body = {
     system_instruction: { parts: [{ text: persona }] },
     contents: buildGeminiContents(turns),
-    generationConfig: { temperature: 0.9, topP: 0.95, maxOutputTokens: maxTokens },
+    generationConfig: {
+      temperature: 0.9,
+      topP: 0.95,
+      maxOutputTokens: maxTokens + headroom,
+    },
   };
 
   const label = `gemini:${GEMINI_MODEL}`;

--- a/src/config.js
+++ b/src/config.js
@@ -289,12 +289,33 @@ module.exports = {
     768,
   ),
   GEMINI_API_KEY: process.env.GEMINI_API_KEY,
-  GEMINI_MODEL: process.env.GEMINI_MODEL || "gemini-2.0-flash",
+  // gemini-2.0-flash is retired ("no longer available", 404). 3.6 over the
+  // newer 3.8 on purpose: this is the last-resort layer, where availability
+  // beats polish, and 3.8 free-tier returned 503 UNAVAILABLE on 3 of 5 probes
+  // while 3.6 went 5/5 (2026-09-06). Google's own 404 body recommends 3.6.
+  GEMINI_MODEL: process.env.GEMINI_MODEL || "gemini-3.6-flash",
+  // Gemini counts thinking against maxOutputTokens too, and it thinks HARD:
+  // measured 673-914 thought tokens for a two-sentence reply. Without this
+  // the last-resort layer returns MAX_TOKENS with a half-finished sentence.
+  // Unlike Groq, Gemini's free tier limits requests/day rather than output
+  // tokens per minute, so a generous ceiling costs nothing.
+  GEMINI_REASONING_HEADROOM: parsePositiveIntEnv(
+    "GEMINI_REASONING_HEADROOM",
+    2048,
+  ),
   GROQ_API_KEY: process.env.GROQ_API_KEY,
+  // Both Llama entries were decommissioned (404 model_not_found) and nobody
+  // noticed for weeks — the chain just fell through to a dead Gemini.
+  // qwen3.8-27b is the one model left on this account that answers 繁中 in
+  // voice AND emits no hidden reasoning, which matters because Groq's free
+  // tier caps *output tokens per minute* at 1000 and counts max_tokens as
+  // expected output: a reasoning model here would need headroom that the
+  // OTPM limit then rejects outright ("Request too large ... on output
+  // tokens"). So this layer stays deliberately single and non-reasoning.
   GROQ_MODELS: (
     process.env.GROQ_MODELS ||
     process.env.GROQ_MODEL ||
-    "llama-3.3-70b-versatile,llama-3.1-8b-instant"
+    "qwen/qwen3.8-27b"
   )
     .split(",")
     .map((s) => s.trim())


### PR DESCRIPTION
> **Stacked on #67** — base 是 `fix/flash-reasoning-headroom`，不是 prod。合併順序：#67 → 本 PR。

## 問題

fallback 鏈的三層**全部是 404**，近 20 天 652 次呼叫 **0 次成功**，`chain exhausted` **359 次**（= 西寶吐罐頭回覆）：

```
groq   404 {"message":"The model `llama-3.3-70b-versatile` does not exist
             or you do not have access to it.","code":"model_not_found"}
groq   404 同上，llama-3.1-8b-instant
gemini 404 {"message":"This model models/gemini-2.0-flash is no longer
             available. Please update your code to use models/gemini-3.6-flash"}
```

模型 id 會自己爛掉，而唯一的症狀是 log 裡一行 `chain exhausted`。

## 選型是實測出來的，不是查文件

**Groq**（`GET /openai/v1/models` 顯示這個帳號已經沒有任何 llama 聊天模型）：

| 候選 | max_tokens=180 的結果 |
|---|---|
| **`qwen/qwen3.8-27b`** | `finish=stop`、reasoning **0**、22 tokens、繁中到位 ✅ |
| `openai/gpt-oss-20b` | `finish=length`、reasoning 403 字、content 只剩 24 字 ❌ |
| `openai/gpt-oss-120b` | reasoning 306 字，勉強 stop，邊緣 |
| `qwen/qwen3.6-27b` | 把原始 `<think>` 直接吐進 content ❌ |

**只留一層、且必須是非推理模型**，因為 Groq 免費層限制 **輸出 token 每分鐘 1000**，而且把 `max_tokens` 當「預期輸出」計算：

```
Request too large for model `qwen/qwen3.8-27b` ... on output tokens per minute
(OTPM): Limit 1000, Requested 1126. reduce max_tokens ...
```

也就是說 —— **在 Groq 這層加 headroom 會直接把請求打掛**。這跟 #67 對 DeepSeek/OpenAI 的做法剛好相反，理由寫進註解了。

**Gemini**：刻意選 `gemini-3.6-flash` 而不是更新的 3.8。這是最後一層，**可用性比文采重要**：

| 模型 | 5 次探測 |
|---|---|
| gemini-3.8-flash | **2/5**（其餘 503 UNAVAILABLE） |
| **gemini-3.6-flash** | **5/5** |

Google 自己的 404 訊息也是建議換 3.6。

## 改動

- `config.js` — `GROQ_MODELS` 預設 → `qwen/qwen3.8-27b`（單一層）；`GEMINI_MODEL` → `gemini-3.6-flash`；新增 `GEMINI_REASONING_HEADROOM`（2048）
- `providers.js` — `callGemini` 補 headroom。`maxOutputTokens` 同樣涵蓋思考（`usageMetadata.thoughtsTokenCount`），實測一句話的回覆要燒 **673~914** 個 thought token，不給餘裕就是 `MAX_TOKENS` 斷在句子中間
- `chain.js` — 更新那段已經過期的註解
- `smoke-ai-circuit.js` — 三個新斷言：擋住已下架的 id、Groq 只有一層且是這次驗過的模型、`callGemini` 的 headroom

## ⚠️ 需要手動配合的 `.env` 改動（已做，但不進 git）

**光改 `config.js` 的預設值不會生效** —— `.env` 有 `GROQ_MODELS=llama-3.3-70b-versatile,llama-3.1-8b-instant` 覆寫著。已經把那行註解掉並留下說明：

```
# GROQ_MODELS 已移除覆寫：這兩個 llama 於 2026-08 前後下架，回 404，
# 而 .env 不進 git，沒人 review 得到，於是 fallback 靜默死了好幾週。
# 現行模型改由 src/config.js 的預設值決定，要換模型請改程式碼。
```

**這正是這個 bug 能活這麼久的結構性原因**：模型 id 藏在一個不進版控、沒人 review 的檔案裡。建議之後模型選擇一律留在程式碼預設值。

## 測試

`npm test` 四層全過：**pure 259 / routing 60 / circuit 57 / voice 16，0 failed**。

另外用真實 API 走完整 `FALLBACK_CHAIN` 端到端驗過，三層都回話：

```
chain: openai:gpt-5.6-luna → groq:qwen/qwen3.8-27b → gemini:gemini-3.6-flash
  openai:gpt-5.6-luna        ok=true "又熬到四點，你的肝是不是已經準備離職了？…"
  groq:qwen/qwen3.8-27b      ok=true "四點？你這是拿命換遊戲紀錄還是寫 code 啊？…"
  gemini:gemini-3.6-flash    ok=true "恭喜你，你的肝已經在默默寫遺書了。…"
```

## 未處理

`classifyHttpFailure` 把 404 歸成 `unknown` → 只給 30 秒 cooldown，然後每次呼叫都重試一次必死的請求。**永久性錯誤（模型不存在）和暫時性錯誤用同一個冷卻策略**，是這個 bug 沒被放大的原因之一。修法可以是新增一個 `model_gone` kind（長 cooldown + 啟動時告警），但那是另一個 concern，沒放進來。

🤖 Generated with [Claude Code](https://claude.com/claude-code)